### PR TITLE
feat(trade-in): add Trade-In functionality in Sales Invoice with automated stock entry

### DIFF
--- a/csf_tz/hooks.py
+++ b/csf_tz/hooks.py
@@ -102,6 +102,7 @@ doctype_list_js = {
 
 # before_install = "csf_tz.install.before_install"
 after_install = [
+   "csf_tz.patches.add_trade_in_module.execute", 
    "csf_tz.patches.add_trade_in_item.execute",
    "csf_tz.patches.add_trade_in_control_account.execute",
    "csf_tz.patches.add_client_script_trade_in_child_table.execute",

--- a/csf_tz/patches.txt
+++ b/csf_tz/patches.txt
@@ -25,6 +25,7 @@ csf_tz.patches.custom_fields.delete_employee_custom_fields
 csf_tz.patches.delete_default_value_fields
 csf_tz.patches.disable_signup_in_website_settings
 csf_tz.patches.update_payware_settings_values_to_csf_tz_settings
+csf_tz.patches.add_trade_in_module
 csf_tz.patches.add_trade_in_item
 csf_tz.patches.add_trade_in_control_account
 csf_tz.patches.add_client_script_trade_in_child_table

--- a/csf_tz/patches/add_server_scripts_for_trade_in.py
+++ b/csf_tz/patches/add_server_scripts_for_trade_in.py
@@ -58,7 +58,7 @@ if items_list:
 else:
     frappe.msgprint("No valid items found for stock entry.")
             """,
-            "module": ""
+            "module": "Trade In"
         },
         {
             "doctype_event": "Before Validate",
@@ -97,7 +97,7 @@ if error_messages:
         msg="<br>".join(error_messages),
     )
             """,
-            "module": ""
+            "module": "Trade In"
         },
         {
             "doctype_event": "Before Validate",
@@ -131,7 +131,7 @@ if total_trade_in_value > allowed_trade_in_value:
         )
     )
             """,
-            "module": ""
+            "module": "Trade In"
         }
     ]
 

--- a/csf_tz/patches/add_trade_in_module.py
+++ b/csf_tz/patches/add_trade_in_module.py
@@ -1,0 +1,18 @@
+import frappe
+
+def execute():
+    # Check if the "Trade In" module already exists
+    trade_in_module = frappe.get_all('Module Def', filters={'module_name': 'Trade In'}, limit=1)
+    
+    if not trade_in_module:
+        # Create the new Trade In Module
+        module = frappe.get_doc({
+            'doctype': 'Module Def',
+            'module_name': 'Trade In',
+            'app_name': 'csf_tz',
+        })
+        module.insert()
+        frappe.db.commit()  # Commit the transaction
+        print("Trade In Module created successfully.")
+    else:
+        print("Trade In Module already exists.")


### PR DESCRIPTION
    - Add 'Is Trade In' checkbox in Sales Invoice for trade-in identification.
    - Automate creation of Trade-In item section and related mandatory fields after install.
    - Automatically create Client Script, Server Script, and Module for Trade-In feature after install.
    - Automatically create Trade-In Item and Trade-In Control Account after install.
    - Automatically create Stock Entry (Material Receipt) on Sales Invoice submit.
    - Link Sales Invoice to Stock Entry using a custom field.