### PR TITLE
feat: Add Trade In Settings functionality in csf_tz_settings

### DIFF
--- a/csf_tz/csf_tz/doctype/csf_tz_settings/csf_tz_settings.js
+++ b/csf_tz/csf_tz/doctype/csf_tz_settings/csf_tz_settings.js
@@ -1,13 +1,13 @@
 // Copyright (c) 2020, Aakvatech and contributors
 // For license information, please see license.txt
 
-frappe.ui.form.on('CSF TZ Settings', {
-	start_sle_gle_reporting: function (frm) {
-        frappe.call({
-            method: 'csf_tz.csftz_hooks.item_reposting.enqueue_reposting_sle_gle',
-            callback: function (data) {
-                console.log(data);
-            }
-        })
-    },
+frappe.ui.form.on("CSF TZ Settings", {
+  start_sle_gle_reporting: function (frm) {
+    frappe.call({
+      method: "csf_tz.csftz_hooks.item_reposting.enqueue_reposting_sle_gle",
+      callback: function (data) {
+        console.log(data);
+      },
+    });
+  },
 });

--- a/csf_tz/csf_tz/doctype/csf_tz_settings/csf_tz_settings.json
+++ b/csf_tz/csf_tz/doctype/csf_tz_settings/csf_tz_settings.json
@@ -27,6 +27,8 @@
   "sle_gle_reposting_start_date",
   "column_break_10",
   "start_sle_gle_reporting",
+  "trade_in_settings_section",
+  "enable_trade_in",
   "sales_invoice_qty_settings_section",
   "override_sales_invoice_qty",
   "payroll_overrides_section",
@@ -294,12 +296,24 @@
    "fieldname": "override_sales_invoice_qty",
    "fieldtype": "Check",
    "label": "Override Sales Invoice Qty"
+  },
+  {
+   "fieldname": "trade_in_settings_section",
+   "fieldtype": "Section Break",
+   "label": "Trade In Settings"
+  },
+  {
+   "default": "0",
+   "description": "Enable this feature to handle trade-in items directly within Sales Invoices.",
+   "fieldname": "enable_trade_in",
+   "fieldtype": "Check",
+   "label": "Enable Trade In"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-12-20 17:03:15.176385",
+ "modified": "2024-12-31 15:59:11.939749",
  "modified_by": "Administrator",
  "module": "CSF TZ",
  "name": "CSF TZ Settings",

--- a/csf_tz/csf_tz/doctype/csf_tz_settings/csf_tz_settings.py
+++ b/csf_tz/csf_tz/doctype/csf_tz_settings/csf_tz_settings.py
@@ -6,6 +6,10 @@ from __future__ import unicode_literals
 import frappe
 from frappe.model.document import Document
 from frappe.installer import update_site_config
+from csf_tz.patches.add_trade_in_module import execute as add_trade_in_module
+from csf_tz.patches.add_trade_in_item import execute as add_trade_in_item
+from csf_tz.patches.add_trade_in_control_account import execute as add_trade_in_control_account
+from csf_tz.patches.delete_trade_in_item_and_account import execute as delete_trade_in_item_and_account
 
 
 class CSFTZSettings(Document):
@@ -19,3 +23,28 @@ class CSFTZSettings(Document):
             "email_qatch_batch_size"
         ):
             update_site_config("email_queue_batch_size", self.email_qatch_batch_size)
+
+    def on_update(self):
+        self.manage_trade_in_functionality()
+
+    def manage_trade_in_functionality(self):
+        # Check if the feature is being enabled
+        if self.enable_trade_in:
+            try:
+                add_trade_in_module()  # Add Trade In module
+                add_trade_in_item()    # Create Trade In item
+                add_trade_in_control_account()  # Create Control Account
+                frappe.msgprint("Trade In feature has been successfully enabled.")
+            except Exception as e:
+                # Log the error and notify the user
+                frappe.log_error(f"Error enabling Trade In feature: {str(e)}")
+                frappe.msgprint(f"Failed to enable Trade In feature: {str(e)}")
+        else:
+            # If the feature is being disabled, delete the associated item and account
+            try:
+                delete_trade_in_item_and_account()  # Delete Trade In item and Control Account
+                frappe.msgprint("Trade In feature has been successfully disabled.")
+            except Exception as e:
+                # Log the error and notify the user
+                frappe.log_error(f"Error disabling Trade In feature: {str(e)}")
+                frappe.msgprint(f"Failed to disable Trade In feature: {str(e)}")        

--- a/csf_tz/csf_tz/sales_invoice.js
+++ b/csf_tz/csf_tz/sales_invoice.js
@@ -25,6 +25,7 @@ frappe.ui.form.on("Sales Invoice", {
     }
     frm.trigger("set_pos");
     frm.trigger("make_sales_invoice_btn");
+    frm.trigger("set_trade_in_field_visibility");
   },
   onload: function (frm) {
     frm.trigger("set_pos");
@@ -37,6 +38,7 @@ frappe.ui.form.on("Sales Invoice", {
       }
     }
     // frm.trigger("update_stock");
+    frm.trigger("set_trade_in_field_visibility");
   },
   customer: function (frm) {
     setTimeout(function () {
@@ -136,7 +138,18 @@ frappe.ui.form.on("Sales Invoice", {
         }
       });
   },
+
   // Trade In Feature
+  set_trade_in_field_visibility: function (frm) {
+    // Fetch the Enable Trade In setting from CSF TZ Settings using get_single_value
+    frappe.db
+      .get_single_value("CSF TZ Settings", "enable_trade_in")
+      .then((enable_trade_in) => {
+        // Show or hide the Custom Is Trade-In checkbox based on the setting
+        frm.set_df_property("custom_is_trade_in", "hidden", !enable_trade_in);
+      });
+  },
+
   custom_is_trade_in: function (frm) {
     if (frm.doc.custom_is_trade_in) {
       // Fetch the company's abbreviation

--- a/csf_tz/hooks.py
+++ b/csf_tz/hooks.py
@@ -102,9 +102,6 @@ doctype_list_js = {
 
 # before_install = "csf_tz.install.before_install"
 after_install = [
-   "csf_tz.patches.add_trade_in_module.execute", 
-   "csf_tz.patches.add_trade_in_item.execute",
-   "csf_tz.patches.add_trade_in_control_account.execute",
    "csf_tz.patches.custom_fields.create_custom_fields_for_trade_in_feature.execute",
     "csf_tz.patches.custom_fields.custom_fields_for_removed_edu_fields_in_csf_tz.execute",
     "csf_tz.patches.remove_stock_entry_qty_field.execute",

--- a/csf_tz/patches/delete_trade_in_item_and_account.py
+++ b/csf_tz/patches/delete_trade_in_item_and_account.py
@@ -1,0 +1,40 @@
+from __future__ import unicode_literals
+import frappe
+
+def execute():
+    # Get the default company from Global Defaults
+    global_defaults = frappe.get_single('Global Defaults')
+    default_company = global_defaults.default_company
+
+    if not default_company:
+        frappe.throw("Default company is not set in Global Defaults.")
+
+    # Fetch the abbreviation for the default company
+    company_details = frappe.get_doc('Company', default_company)
+    company_abbr = company_details.abbr
+
+    # Define account name and item name based on the abbreviation
+    trade_in_control_account = f'Trade In Control - {company_abbr}'
+    trade_in_item = "Trade In"
+
+    # Delete Trade In Control account if it exists
+    if frappe.db.exists('Account', {'account_name': trade_in_control_account, 'company': default_company}):
+        try:
+            frappe.delete_doc('Account', trade_in_control_account)
+            print(f"{trade_in_control_account} account has been deleted.")
+        except Exception as e:
+            frappe.log_error(message=str(e), title=f"Error deleting {trade_in_control_account}")
+            print(f"Failed to delete {trade_in_control_account}: {str(e)}")
+    else:
+        print(f"{trade_in_control_account} account does not exist.")
+
+    # Delete Trade In item if it exists
+    if frappe.db.exists('Item', trade_in_item):
+        try:
+            frappe.delete_doc('Item', trade_in_item)
+            print(f"{trade_in_item} has been deleted.")
+        except Exception as e:
+            frappe.log_error(message=str(e), title=f"Error deleting {trade_in_item}")
+            print(f"Failed to delete {trade_in_item}: {str(e)}")
+    else:
+        print(f"{trade_in_item} does not exist.")


### PR DESCRIPTION
- Added 'Enable Trade In' checkbox field in CSF TZ Settings.
- Implemented Python code in csf_tz_settings.py to manage enabling or disabling the Trade In feature.
- Added functionality to delete the Trade In Item and Account via a patch if the feature is disabled in settings.
- Made 'Is Trade In' checkbox visible in Sales Invoice when the feature is enabled.