### PR TITLE
fix: set no_copy property for trade_in custom fields & fix validations of Trade-In feature

### DIFF
--- a/csf_tz/csf_tz/sales_invoice.js
+++ b/csf_tz/csf_tz/sales_invoice.js
@@ -166,11 +166,13 @@ frappe.ui.form.on("Sales Invoice", {
             item_code: "Trade In",
             item_name: "Trade In",
             income_account: `Trade In Control - ${abbr}`, // Set income account dynamically
+            warehouse: `Stores - ${abbr}`,
             uom: "Nos", // Set unit of measure
             qty: 1, // Set quantity to 1
             description: "Trade-In", // Set description
           });
           frm.refresh_field("items");
+          // frm.set_value("set_warehouse", `Stores - ${abbr}`);
         }
       });
     } else {

--- a/csf_tz/patches/custom_fields/create_custom_fields_for_trade_in_feature.py
+++ b/csf_tz/patches/custom_fields/create_custom_fields_for_trade_in_feature.py
@@ -9,7 +9,8 @@ def execute():
                 "fieldtype": "Section Break",
                 "insert_after": "page_break",
                 "label": "Trade In Details",
-                "depnds_on": "eval:doc.item_code == \"Trade In\""
+                "depnds_on": "eval:doc.item_code == \"Trade In\"",
+               
             },
             {
                 "fieldname": "custom_trade_in_item",
@@ -17,14 +18,16 @@ def execute():
                 "insert_after": "custom_trade_in_details",
                 "label": "Item",
                 "options": "Item",
-                "mandatory_depends_on": "eval:doc.item_code == \"Trade In\""
+                "mandatory_depends_on": "eval:doc.item_code == \"Trade In\"",
+                "no_copy": 1
             },
             {
                 "fieldname": "custom_trade_in_qty",
                 "fieldtype": "Float",
                 "insert_after": "custom_trade_in_item",
                 "label": "Qty",
-                "mandatory_depends_on": "eval:doc.item_code == \"Trade In\""
+                "mandatory_depends_on": "eval:doc.item_code == \"Trade In\"",
+                "no_copy": 1
             },
             {
                 "fieldname": "custom_trade_in_uom",
@@ -32,6 +35,7 @@ def execute():
                 "insert_after": "custom_trade_in_qty",
                 "label": "UOM",
                 "options": "UOM",
+                "no_copy": 1
             },
             {
                 "fieldname": "custom_trade_in_column",
@@ -44,7 +48,8 @@ def execute():
                 "fieldtype": "Currency",
                 "insert_after": "custom_trade_in_column",
                 "label": "Incoming Rate",
-                "mandatory_depends_on": "eval:doc.item_code == \"Trade In\""
+                "mandatory_depends_on": "eval:doc.item_code == \"Trade In\"",
+                "no_copy": 1
             },
             {
                 "fieldname": "custom_total_trade_in_value",
@@ -52,18 +57,21 @@ def execute():
                 "insert_after": "custom_trade_in_incoming_rate",
                 "label": "Total Trade In Value",
                 "read_only": 1,
+                "no_copy": 1
             },
             {
                 "fieldname": "custom_trade_in_batch_no",
                 "fieldtype": "Data",
                 "insert_after": "custom_total_trade_in_value",
                 "label": "Trade In Batch No",
+                "no_copy": 1
             },
             {
                 "fieldname": "custom_trade_in_serial_no",
                 "fieldtype": "Small Text",
                 "insert_after": "custom_trade_in_batch_no",
                 "label": "Trade In Serial No",
+                "no_copy": 1
             }
         ],
         "Sales Invoice": [
@@ -72,7 +80,8 @@ def execute():
                 "fieldtype": "Check",
                 "insert_after": "update_stock",
                 "label": "Is Trade In",
-                "depends_on": "eval:doc.customer"
+                "depends_on": "eval:doc.customer",
+                "no_copy": 1
             }
         ],
          "Stock Entry": [
@@ -82,7 +91,8 @@ def execute():
                 "options": "Sales Invoice",
                 "insert_after": "Stock Entry Type",
                 "label": "Sales Invoice",
-                "depends_on": "eval:doc.stock_entry_type == 'Material Receipt'"
+                "depends_on": "eval:doc.stock_entry_type == 'Material Receipt'",
+                "no_copy": 1
             }
         ],
         "Company": [

--- a/csf_tz/patches/custom_fields/create_custom_fields_for_trade_in_feature.py
+++ b/csf_tz/patches/custom_fields/create_custom_fields_for_trade_in_feature.py
@@ -89,7 +89,7 @@ def execute():
                 "fieldname": "custom_sales_invoice",
                 "fieldtype": "Link",
                 "options": "Sales Invoice",
-                "insert_after": "Stock Entry Type",
+                "insert_after": "stock_entry_type",
                 "label": "Sales Invoice",
                 "depends_on": "eval:doc.stock_entry_type == 'Material Receipt'",
                 "no_copy": 1


### PR DESCRIPTION
- Updated the custom field configuration to prevent copying of the trade_in field across document instances.
- Ensures better data integrity and avoids unintended data duplication.
- Ensure sales percentage validation only triggers for the is_trade_in field.
- During automatic creation of the Material Receipt, fetch the specified warehouse of the Trade-In item and set it in the Material Receipt.
- Apply minor bug fixes for enabling/disabling the Trade-In feature in the CSF TZ settings.
- When enabling or disabling the Trade-In feature, ensure the Trade-In item is enabled or disabled instead of deleted.
- In the Material Receipt, link the Sales Invoice field after the stock entry type.
- Maintain stock disable status for the Trade-In item.
