### PR TITLE
feat: Add utility function to enable "Allow Negative Rates for Items" in Selling Settings

### DIFF
--- a/csf_tz/csf_tz/doctype/csf_tz_settings/csf_tz_settings.py
+++ b/csf_tz/csf_tz/doctype/csf_tz_settings/csf_tz_settings.py
@@ -10,7 +10,8 @@ from csf_tz.trade_in.utils import (
     add_trade_in_module,
     add_trade_in_item,
     add_trade_in_control_account,
-    delete_trade_in_item_and_account
+    delete_trade_in_item_and_account,
+    set_negative_rates_for_items
 )
 
 
@@ -37,6 +38,7 @@ class CSFTZSettings(Document):
                 add_trade_in_module()  # Add Trade In module
                 add_trade_in_item()    # Create Trade In item
                 add_trade_in_control_account()  # Create Control Account
+                set_negative_rates_for_items()  # Create Control Account
                 frappe.msgprint("Trade In feature has been successfully enabled.")
             except Exception as e:
                 # Log the error and notify the user

--- a/csf_tz/trade_in/utils.py
+++ b/csf_tz/trade_in/utils.py
@@ -170,8 +170,6 @@ def set_negative_rates_for_items():
         selling_settings.allow_negative_rates_for_items = 1
         selling_settings.save()
 
-        # Commit changes to the database
-        frappe.db.commit()
         print("Allow Negative Rates for Items set to 1 successfully.")
     
     except Exception as e:

--- a/csf_tz/trade_in/utils.py
+++ b/csf_tz/trade_in/utils.py
@@ -160,3 +160,22 @@ def delete_trade_in_item_and_account():
         print(f"{trade_in_item} does not exist.")
 
 
+def set_negative_rates_for_items():
+    #Set the 'allow_negative_rates_for_items' field in the Selling Settings
+    try:
+        # Get Selling Settings single doctype
+        selling_settings = frappe.get_single('Selling Settings')
+
+        # Set 'allow_negative_rates_for_items' to 1
+        selling_settings.allow_negative_rates_for_items = 1
+        selling_settings.save()
+
+        # Commit changes to the database
+        frappe.db.commit()
+        print("Allow Negative Rates for Items set to 1 successfully.")
+    
+    except Exception as e:
+        frappe.log_error(message=str(e), title="Error Setting Allow Negative Rates for Items")
+        print(f"An error occurred: {e}")
+
+


### PR DESCRIPTION
 - Added `set_negative_rates_for_items` function in `utils.py` to enable the "Allow Negative Rates for Items" setting in the Selling Settings doctype.
 - Imported the function into `csf_tz_settings.py` and integrated it with the "Enable Trade In" feature to set the value dynamically.