### PR TITLE
fix: resolve validation for trade-in feature

### DIFF
--- a/csf_tz/custom_api.py
+++ b/csf_tz/custom_api.py
@@ -2997,7 +2997,6 @@ def create_trade_in_stock_entry(doc, method):
         return
 
     trade_in_control_account = company_details.get("custom_trade_in_control_account")
-    company_abbr = company_details.get("abbr")
 
     if not trade_in_control_account:
         frappe.throw(

--- a/csf_tz/custom_api.py
+++ b/csf_tz/custom_api.py
@@ -3000,8 +3000,9 @@ def create_trade_in_stock_entry(doc, method):
     company_abbr = company_details.get('abbr')
 
     if not trade_in_control_account:
-           frappe.throw(f"Trade-In Control Account not configured for {doc.company}. Please set it in the <a href='/app/company/{doc.company}'>Company settings</a>.")
-           return
+        frappe.throw(f"Trade-In Control Account not configured for {doc.company}. Please set it in the <a href='/app/company/{doc.company}'>Company settings</a>.")
+        return
+
     # Iterate through the items in the document
     for item in doc.items:
         if item.get("custom_trade_in_item") and item.get("custom_trade_in_qty"):

--- a/csf_tz/custom_api.py
+++ b/csf_tz/custom_api.py
@@ -2883,6 +2883,10 @@ def get_item_prices_po(item_code, currency, customer=None, company=None):
     return prices_list
 
 def validate_trade_in_serial_no_and_batch(doc, method):
+    # Check if "custom_is_trade_in" is checked
+    if not doc.custom_is_trade_in:
+        return  # Skip validation if trade-in is not applicable
+        
     error_messages = []
     for row in doc.items:
         if row.item_code == "Trade In" and row.custom_trade_in_item:
@@ -2969,6 +2973,10 @@ def validate_trade_in_sales_percentage(doc, method):
 
 
 def create_trade_in_stock_entry(doc, method):
+    # Check if "custom_is_trade_in" is checked
+    if not doc.custom_is_trade_in:
+        return  # Skip validation if trade-in is not applicable
+
     # Initialize an empty list to store items
     items_list = []
 
@@ -3017,6 +3025,7 @@ def create_trade_in_stock_entry(doc, method):
                 "serial_no": item.get("custom_trade_in_serial_no"),  # Get custom serial number value
                 "expense_account": trade_in_control_account,
                 "t_warehouse": item.get("warehouse"),  # Use the warehouse from the Sales Invoice child table
+                "use_serial_batch_fields" : 1
             })
 
     # Create a single stock entry if there are items to add


### PR DESCRIPTION
- add trade_in_flag_check decorator for conditional validation
- Execute validation only when "is_trade_in" is checked in the Sales Invoice.
- Ensures unnecessary validation is skipped when trade-in is not applicable.