### PR TITLE
feat: Make UOM non-mandatory for Trade-In Items and add custom UOM field

### DIFF
--- a/csf_tz/csf_tz/sales_invoice.js
+++ b/csf_tz/csf_tz/sales_invoice.js
@@ -242,11 +242,19 @@ frappe.ui.form.on("Sales Invoice Item", {
     let row = locals[cdt][cdn];
 
     // Debugging: Log the row and frm
-    // console.log("Row data:", row);
+    //console.log("Row data:", row);
     // console.log("Form data:", frm);
 
     // Ensure row is defined before calling the function
     if (row) {
+      // Check if the item_code is "Trade In"
+      if (row.item_code === "Trade In") {
+        // Use toggle_reqd to make the UOM field non-mandatory
+        cur_frm.fields_dict.items.grid.toggle_reqd("uom", false);
+      } else {
+        // For non "Trade In" items, make the UOM field mandatory
+        cur_frm.fields_dict.items.grid.toggle_reqd("uom", true);
+      }
       set_trade_in_fields_readonly(frm, row);
     } else {
       // console.error("Row is undefined.");

--- a/csf_tz/csf_tz/sales_invoice.js
+++ b/csf_tz/csf_tz/sales_invoice.js
@@ -152,43 +152,39 @@ frappe.ui.form.on("Sales Invoice", {
 
   custom_is_trade_in: function (frm) {
     if (frm.doc.custom_is_trade_in) {
-      frappe.db.get_value("Company", frm.doc.company, "abbr", function (res) {
-        if (!res || !res.abbr) return; // Exit if abbreviation is missing
-        let abbr = res.abbr;
+      frappe.db
+        .get_value("Company", frm.doc.company, [
+          "custom_trade_in_control_account",
+        ])
+        .then((company_res) => {
+          const trade_in_account =
+            company_res?.message?.custom_trade_in_control_account;
+          if (!trade_in_account)
+            frappe.throw(
+              __("Trade-In Control Account is not set in Company settings.")
+            );
 
-        // Check if "Trade In" item is already added
-        if (!frm.doc.items.some((item) => item.item_code === "Trade In")) {
-          // Fetch Default UOM from Item Master
-          frappe.db.get_value("Item", "Trade In", "stock_uom", function (data) {
-            let row = frm.add_child("items", {
+          if (!frm.doc.items.some((item) => item.item_code === "Trade In")) {
+            frm.add_child("items", {
               item_code: "Trade In",
               item_name: "Trade In",
-              income_account: `Trade In Control - ${abbr}`, // Set income account dynamically
-              warehouse: `Stores - ${abbr}`, // Set warehouse dynamically
-              uom: data.stock_uom, // Directly use UOM from Item Master
-              qty: 1, // Default quantity
+              income_account: trade_in_account,
+              qty: 1,
               description: "Trade-In",
             });
-
-            frm.refresh_field("items"); // Refresh item table
-          });
-        }
-      });
+            frm.refresh_field("items");
+          }
+        });
     } else {
-      // Confirm before removing "Trade In"
       frappe.confirm(
         'Are you sure you want to remove the "Trade In" item?',
-        function () {
-          // Remove the "Trade In" item if exists
+        () => {
           frm.doc.items = frm.doc.items.filter(
             (item) => item.item_code !== "Trade In"
           );
           frm.refresh_field("items");
         },
-        function () {
-          // Re-check the checkbox if user cancels
-          frm.set_value("custom_is_trade_in", 1);
-        }
+        () => frm.set_value("custom_is_trade_in", 1)
       );
     }
   },

--- a/csf_tz/csf_tz/sales_invoice.js
+++ b/csf_tz/csf_tz/sales_invoice.js
@@ -161,7 +161,7 @@ frappe.ui.form.on("Sales Invoice", {
             company_res?.message?.custom_trade_in_control_account;
           if (!trade_in_account)
             frappe.throw(
-              __("Trade-In Control Account is not set in Company settings.")
+              "Trade-In Control Account is not set in Company settings."
             );
 
           if (!frm.doc.items.some((item) => item.item_code === "Trade In")) {

--- a/csf_tz/custom_api.py
+++ b/csf_tz/custom_api.py
@@ -2976,11 +2976,11 @@ def create_trade_in_stock_entry(doc, method):
     # Initialize an empty list to store items
     items_list = []
 
-    # Fetch Company's Trade_in_control_account and abbreviation
+    # Fetch Company's Trade_in_control_account
     company_details = frappe.db.get_value(
         "Company",
         doc.company,
-        ["custom_trade_in_control_account", "abbr"],
+        ["custom_trade_in_control_account"],
         as_dict=True,
     )
     if not company_details:
@@ -3045,14 +3045,12 @@ def create_trade_in_stock_entry(doc, method):
             # Insert and submit the Stock Entry
             stock_entry.insert()
             stock_entry.submit()
-            frappe.db.commit()
 
             # Notify the user
             frappe.msgprint(
                 f"Stock Entry <a href='/app/stock-entry/{stock_entry.name}' target='_blank'>{stock_entry.name}</a> created successfully!"
             )
         except Exception as e:
-            frappe.db.rollback()
             frappe.throw(f"Error during Stock Entry creation: {str(e)}")
     else:
         frappe.msgprint("No valid items found for stock entry.")

--- a/csf_tz/hooks.py
+++ b/csf_tz/hooks.py
@@ -104,7 +104,6 @@ doctype_list_js = {
 
 # before_install = "csf_tz.install.before_install"
 after_install = [
-   "csf_tz.patches.custom_fields.create_custom_fields_for_trade_in_feature.execute",
     "csf_tz.patches.custom_fields.custom_fields_for_removed_edu_fields_in_csf_tz.execute",
     "csf_tz.patches.remove_stock_entry_qty_field.execute",
     "csf_tz.patches.remove_core_doctype_custom_docperm.execute",
@@ -120,7 +119,8 @@ after_install = [
 after_migrate = [
     "csf_tz.utils.create_custom_fields.execute",
     "csf_tz.utils.create_property_setter.execute",
-    "csf_tz.patches.update_payware_settings_values_to_csf_tz_settings.execute"
+    "csf_tz.patches.update_payware_settings_values_to_csf_tz_settings.execute",
+    "csf_tz.patches.custom_fields.create_custom_fields_for_trade_in_feature.execute",
 ]
 
 # Desk Notifications

--- a/csf_tz/patches/custom_fields/create_custom_fields_for_trade_in_feature.py
+++ b/csf_tz/patches/custom_fields/create_custom_fields_for_trade_in_feature.py
@@ -72,7 +72,17 @@ def execute():
                 "insert_after": "custom_trade_in_batch_no",
                 "label": "Trade In Serial No",
                 "no_copy": 1
-            }
+            },
+   {
+                "fieldname": "custom_uom",
+                "fieldtype": "Link",
+                "insert_after": "item_code",
+                "label": "UOM",
+                "options": "UOM",
+                "no_copy": 1,
+                "fetch_from": "item_code.stock_uom",
+                "depends_on": "eval:doc.item_code == \"Trade In\"",
+            },
         ],
         "Sales Invoice": [
             {


### PR DESCRIPTION

-Made the UOM field non-mandatory for Trade-In Items.
-Added custom_uom field in Sales Invoice child table, visible only for Trade-In Items, fetching UOM using 'Fetched From'.
-Moved Trade-In feature-related custom field creation file path from after install to after_migrate, so the custom field will be created automatically on migration.