### PR TITLE
feat: Add AV Sales Invoice Trend report with available qty and warehouse info

### DIFF
--- a/csf_tz/csf_tz/report/av_sales_invoice_trend/av_sales_invoice_trend.js
+++ b/csf_tz/csf_tz/report/av_sales_invoice_trend/av_sales_invoice_trend.js
@@ -1,0 +1,7 @@
+// Copyright (c) 2025, Aakvatech and contributors
+// For license information, please see license.txt
+
+frappe.query_reports["AV Sales Invoice Trend"] = $.extend(
+  {},
+  erpnext.sales_trends_filters
+);

--- a/csf_tz/csf_tz/report/av_sales_invoice_trend/av_sales_invoice_trend.json
+++ b/csf_tz/csf_tz/report/av_sales_invoice_trend/av_sales_invoice_trend.json
@@ -1,0 +1,34 @@
+{
+ "add_total_row": 1,
+ "add_translate_data": 0,
+ "columns": [],
+ "creation": "2025-04-11 16:20:18.640105",
+ "disabled": 0,
+ "docstatus": 0,
+ "doctype": "Report",
+ "filters": [],
+ "idx": 0,
+ "is_standard": "Yes",
+ "letterhead": null,
+ "modified": "2025-04-12 00:02:14.084115",
+ "modified_by": "Administrator",
+ "module": "CSF TZ",
+ "name": "AV Sales Invoice Trend",
+ "owner": "Administrator",
+ "prepared_report": 0,
+ "ref_doctype": "Sales Invoice",
+ "report_name": "AV Sales Invoice Trend",
+ "report_type": "Script Report",
+ "roles": [
+  {
+   "role": "Accounts Manager"
+  },
+  {
+   "role": "Accounts User"
+  },
+  {
+   "role": "Employee Self Service"
+  }
+ ],
+ "timeout": 0
+}

--- a/csf_tz/csf_tz/report/av_sales_invoice_trend/av_sales_invoice_trend.py
+++ b/csf_tz/csf_tz/report/av_sales_invoice_trend/av_sales_invoice_trend.py
@@ -1,0 +1,48 @@
+import frappe
+from erpnext.controllers.trends import get_columns, get_data
+from frappe.utils import flt
+
+def execute(filters=None):
+	filters = filters or {}
+
+	# Get standard columns and data
+	result = get_columns(filters, "Sales Invoice")
+	columns, data = result["columns"], get_data(filters, result)
+
+	# Find the index of the item_code column
+	item_idx = next((i for i, col in enumerate(columns)
+	                 if isinstance(col, dict) and col.get("fieldname") in ("item_code", "item")), 0)
+
+	# Fetch Bin summary with formatted qty
+	bin_map = {
+		d.item_code: [flt(d.total_qty, 2), d.warehouse_summary]
+		for d in frappe.db.sql("""
+			SELECT
+				item_code,
+				SUM(actual_qty) AS total_qty,
+				GROUP_CONCAT(CONCAT(warehouse, ": ", FORMAT(actual_qty, 2)) SEPARATOR ", ") AS warehouse_summary
+			FROM `tabBin`
+			GROUP BY item_code
+		""", as_dict=True)
+	}
+
+	# Add Bin info to each row
+	for row in data:
+		row += bin_map.get(row[item_idx], [0.00, ""])
+
+	# Add columns for available qty and warehouse summary
+	columns += [
+		{
+			"label": "Total Available Qty",
+			"fieldname": "total_available_qty",
+			"fieldtype": "Float",
+			"precision": 2
+		},
+		{
+			"label": "Warehouse",
+			"fieldname": "warehouse",
+			"fieldtype": "Data"
+		},
+	]
+
+	return columns, data


### PR DESCRIPTION
### Summary

This PR adds a new custom report **"AV Sales Invoice Trend"** under the CSF TZ app.  
It extends the standard Sales Invoice Trends report by including additional inventory details.

### Key Enhancements

- Added two new columns:
  - **Total Available Qty**: Summed quantity from the `Bin` doctype.
  - **Warehouse**: Grouped warehouse summary using `GROUP_CONCAT
