### PR TITLE
fix: update JS file paths in hooks.py to resolve 404 errors in csf_tz app

### DIFF
--- a/csf_tz/hooks.py
+++ b/csf_tz/hooks.py
@@ -26,9 +26,9 @@ override_doctype_class = {
 # app_include_css = "/assets/csf_tz/css/csf_tz.css"
 # app_include_js = "/assets/csf_tz/js/csf_tz.js"
 app_include_js = [
-    "/assets/js/select_dialog.min.js",
-    "/assets/js/to_console.min.js",
-    "/assets/js/jobcards.min.js",
+    "/assets/csf_tz/js/select_dialog.js",
+    "/assets/csf_tz/js/to_console.js",
+    "/assets/csf_tz/js/jobcards/jobcards.js",
     "/assets/csf_tz/node_modules/vuetify/dist/vuetify.js",
 ]
 


### PR DESCRIPTION
### Overview:
The issue was caused by incorrect file paths in the `app_include_js` section of the `hooks.py` file in the `csf_tz` app. This led to 404 errors due to missing minified JS files.

### Changes:
- Updated the paths in `app_include_js` to point to the correct files inside the app's directory.
- Replaced the incorrect paths with valid ones for proper inclusion of JS files.

### Impact:
- The issue with missing JS files and 404 errors has been resolved.
- The app should now load the required JS files correctly.