### PR TITLE
Fix typo in payroll PDF console message

### DIFF
--- a/csf_tz/csftz_hooks/payroll.py
+++ b/csf_tz/csftz_hooks/payroll.py
@@ -142,7 +142,7 @@ def enqueue_print_slips(kwargs):
             }
         )
         ret.save(ignore_permissions=1)
-        console("Printing Finished", "The PDF file is ready in attatchments")
+        console("Printing Finished", "The PDF file is ready in attachments")
         return ret
 
 


### PR DESCRIPTION
## Summary
- fix minor typo in payroll PDF attachment console message

## Testing
- `pytest -q` *(fails: 133 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6848abb79c0c833088e9b3a9624f7fb4