### PR TITLE
Fix PDF write in payroll hook

### DIFF
--- a/csf_tz/csftz_hooks/payroll.py
+++ b/csf_tz/csftz_hooks/payroll.py
@@ -174,7 +174,8 @@ def download_multi_pdf(doctype, name, format=None, no_letterhead=0):
 
 def read_multi_pdf(output):
     fname = os.path.join("/tmp", "frappe-pdf-{0}.pdf".format(frappe.generate_hash()))
-    output.write(open(fname, "wb"))
+    with open(fname, "wb") as f:
+        output.write(f)
 
     with open(fname, "rb") as fileobj:
         filedata = fileobj.read()


### PR DESCRIPTION
## Summary
- close the temporary PDF file handle before reading it

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_e_6848abcf78888330b9ce42e1167accc3