### PR TITLE
Fix licence reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ For support and assistance, please create a github issue.
 
 ## **Licence**
 
-This project is licensed under the GNU General Public License (GPL). See the LICENCE file for more details.
+This project is licensed under the GNU General Public License (GPL). See the license.txt file for more details.
 
 ---
 


### PR DESCRIPTION
## Summary
- update licence section to use `license.txt`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'frappe')*

------
https://chatgpt.com/codex/tasks/task_e_6848abdf7d2c8330a052dfecd69bca82