### PR TITLE
feat(vehicle_sync_task): add log cleanup method and fixture for log retention

### DIFF
--- a/csf_tz/csf_tz/doctype/vehicle_sync_task/vehicle_sync_task.json
+++ b/csf_tz/csf_tz/doctype/vehicle_sync_task/vehicle_sync_task.json
@@ -28,6 +28,7 @@
   {
    "fieldname": "vehicle_no",
    "fieldtype": "Data",
+   "in_list_view": 1,
    "label": "Vehicle No",
    "no_copy": 1,
    "unique": 1
@@ -35,6 +36,7 @@
   {
    "fieldname": "status",
    "fieldtype": "Select",
+   "in_list_view": 1,
    "label": "Status",
    "options": "\nPending\nProcessing\nDone\nFailed\nPaused",
    "search_index": 1
@@ -63,6 +65,7 @@
   {
    "fieldname": "next_run_at",
    "fieldtype": "Datetime",
+   "in_list_view": 1,
    "label": "Next Run at",
    "search_index": 1
   },
@@ -127,7 +130,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-08-29 23:03:54.516203",
+ "modified": "2025-09-14 21:43:07.623030",
  "modified_by": "Administrator",
  "module": "CSF TZ",
  "name": "Vehicle Sync Task",
@@ -150,5 +153,26 @@
  "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
- "states": []
+ "states": [
+  {
+   "color": "Yellow",
+   "title": "Pending"
+  },
+  {
+   "color": "Blue",
+   "title": "Processing"
+  },
+  {
+   "color": "Green",
+   "title": "Done"
+  },
+  {
+   "color": "Red",
+   "title": "Failed"
+  },
+  {
+   "color": "Gray",
+   "title": "Paused"
+  }
+ ]
 }

--- a/csf_tz/csf_tz/doctype/vehicle_sync_task/vehicle_sync_task.py
+++ b/csf_tz/csf_tz/doctype/vehicle_sync_task/vehicle_sync_task.py
@@ -1,9 +1,13 @@
 # Copyright (c) 2025, Aakvatech and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
-
+from frappe.query_builder import Interval
+from frappe.query_builder.functions import Now
 
 class VehicleSyncTask(Document):
-	pass
+    @staticmethod
+    def clear_old_logs(days=7):
+        table = frappe.qb.DocType("Vehicle Sync Task")
+        frappe.db.delete(table, filters=(table.creation < (Now() - Interval(days=days))))

--- a/csf_tz/fixtures/log_settings.json
+++ b/csf_tz/fixtures/log_settings.json
@@ -1,0 +1,17 @@
+[
+  {
+    "docstatus": 0,
+    "doctype": "Log Settings",
+    "logs_to_clear": [
+      {
+        "days": 7,
+        "parent": "Log Settings",
+        "parentfield": "logs_to_clear",
+        "parenttype": "Log Settings",
+        "ref_doctype": "Vehicle Sync Task"
+      }
+    ],
+    "modified": "2025-09-14 23:21:17.887351",
+    "name": "Log Settings"
+  }
+]

--- a/csf_tz/hooks.py
+++ b/csf_tz/hooks.py
@@ -274,7 +274,7 @@ scheduler_events = {
     # 	"csf_tz.tasks.all"
     # ],
     "cron": { 
-        # Every minute - process exactly 5 vehicles
+       
         "* * * * *": [
             "csf_tz.csf_tz.doctype.vehicle_sync_task.processor.run_vehicle_batch"
         ],
@@ -337,3 +337,7 @@ override_whitelisted_methods = {
     "erpnext.stock.doctype.material_request.material_request.update_status": "csf_tz.csftz_hooks.material_request.update_mr_status",
     "erpnext.stock.get_item_details.get_item_details": "csf_tz.csftz_hooks.custom_get_item_details.custom_get_item_details",
 }
+
+
+fixtures = ["Log Settings"]
+


### PR DESCRIPTION
### Summary

This PR implements automatic log cleanup for the Vehicle Sync Task doctype and adds a corresponding fixture to maintain log retention settings.

### Changes

- Added a static method `clear_old_logs` in `VehicleSyncTask` to delete logs older than the configured retention period.
- Created Log Settings fixture that includes "Vehicle Sync Task" with a 7-day log retention.