### PR TITLE
fix: add missing HTML field in Feedback Web Form

### DIFF
--- a/csf_tz/feedback/doctype/feedback_form/feedback_form.json
+++ b/csf_tz/feedback/doctype/feedback_form/feedback_form.json
@@ -70,13 +70,14 @@
   {
    "fieldname": "dynamic_html",
    "fieldtype": "Data",
+   "hidden": 1,
    "label": "Dynamic HTML"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-09-19 16:35:32.501978",
+ "modified": "2025-09-19 16:41:16.429427",
  "modified_by": "Administrator",
  "module": "Feedback",
  "name": "Feedback Form",

--- a/csf_tz/feedback/doctype/feedback_form/feedback_form.json
+++ b/csf_tz/feedback/doctype/feedback_form/feedback_form.json
@@ -15,7 +15,8 @@
   "contact_no",
   "section_break_itfe",
   "responses",
-  "dynamic_questions"
+  "dynamic_questions",
+  "dynamic_html"
  ],
  "fields": [
   {
@@ -65,12 +66,17 @@
   {
    "fieldname": "column_break_ldsy",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "dynamic_html",
+   "fieldtype": "Data",
+   "label": "Dynamic HTML"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-07-27 23:21:52.858580",
+ "modified": "2025-09-19 16:35:32.501978",
  "modified_by": "Administrator",
  "module": "Feedback",
  "name": "Feedback Form",


### PR DESCRIPTION
The HTML field was not included earlier in the Feedback Web Form. 
This commit fixes the issue by adding the field properly so it renders 
as expected on the form.