### PR TITLE
feat(Job Opening): add job opening template with salary range and application link into csf tz to override the job opening template from HRMS

### DIFF
--- a/csf_tz/templates/generators/job_opening.html
+++ b/csf_tz/templates/generators/job_opening.html
@@ -1,0 +1,19 @@
+
+<div class="my-5 p-4 border rounded shadow-sm">
+	<h3 class="text-center mb-2">{{ doc.job_title }}</h3>
+	<p >{{ doc.description }}</p>
+	{%- if doc.publish_salary_range -%}
+	<p><b>{{_("Salary range per month")}}: </b>{{ frappe.format_value(frappe.utils.flt(doc.lower_range), currency=doc.currency) }} - {{ frappe.format_value(frappe.utils.flt(doc.upper_range), currency=doc.currency) }}</p>
+	{% endif %}
+	<div class="text-right" style='margin-top: 30px'>
+		{%- if doc.job_application_route -%}
+		<a class='btn btn-primary'
+		href='/{{doc.job_application_route}}/new?job_title={{ doc.name }}'>
+		{{ _("Apply Now") }}</a>
+		{% else %}
+		<a class='btn btn-primary'
+		href='/job_application/new?job_title={{ doc.name }}'>
+		{{ _("Apply Now") }}</a>
+		{% endif %}
+	</div>
+</div>


### PR DESCRIPTION
Problem:
<img width="1097" height="513" alt="image" src="https://github.com/user-attachments/assets/1c424418-9b16-412e-b06c-2a37bb4b5141" />
<img width="1593" height="874" alt="image" src="https://github.com/user-attachments/assets/c9305ecc-8dd6-4e51-aaf7-33e0dbdd9f9e" />


Solution:
<img width="1306" height="804" alt="image" src="https://github.com/user-attachments/assets/d3aafcc6-43c2-48bc-a56f-aaa5b0e9ee1e" />
<img width="1314" height="871" alt="image" src="https://github.com/user-attachments/assets/128219b0-b582-4388-af24-20c6903400e9" />
<img width="1172" height="911" alt="image" src="https://github.com/user-attachments/assets/29d584ac-2fea-440b-bf37-5e9995ab2baa" />
