### PR TITLE
fix(employee): set employee location custom field as select for PAYE

### DIFF
--- a/csf_tz/patches/custom_fields/custom_fields_json/14_employee_paye_fields.json
+++ b/csf_tz/patches/custom_fields/custom_fields_json/14_employee_paye_fields.json
@@ -16,7 +16,8 @@
     "label": "Employee Location",
     "fieldname": "employee_location",
     "insert_after": "branch",
-    "fieldtype": "Data",
+    "fieldtype": "Select",
+    "options": "\nTanzania Mainland\nZanzibar",
     "translatable": 1,
     "doctype": "Custom Field"
   }


### PR DESCRIPTION
- change Employee employee_location from Data to Select
- add options: Tanzania Mainland and Zanzibar
- keep PAYE employee custom fields in JSON patch definition