### PR TITLE
fix: create overtime threshold fields on install/migrate

### DIFF
--- a/csf_tz/hooks.py
+++ b/csf_tz/hooks.py
@@ -116,6 +116,7 @@ after_install = [
 	"csf_tz.patches.custom_fields.create_custom_fields_for_additional_salary.execute",
 	"csf_tz.patches.custom_fields.payroll_approval_custom_fields.execute",
 	"csf_tz.patches.custom_fields.vfd_providers_updated_custom_fields.execute",
+	"csf_tz.patches.custom_fields.attendance_overtime_calculation_custom_fields.execute",
 	"csf_tz.patches.migrate_vfd_providers_to_csf_tz.execute",
 	"csf_tz.utils.create_custom_fields.execute",
 	"csf_tz.utils.create_property_setter.execute",
@@ -127,6 +128,7 @@ after_migrate = [
 	"csf_tz.utils.create_property_setter.execute",
 	"csf_tz.patches.update_payware_settings_values_to_csf_tz_settings.execute",
 	"csf_tz.patches.custom_fields.vfd_providers_updated_custom_fields.execute",
+	"csf_tz.patches.custom_fields.attendance_overtime_calculation_custom_fields.execute",
 	"csf_tz.patches.migrate_vfd_providers_to_csf_tz.execute",
 ]
 


### PR DESCRIPTION
Add attendance_overtime_calculation_custom_fields to after_install and after_migrate hooks so the Shift Type overtime fields get created. Fresh installs skip patches, so they never ran otherwise.