### PR TITLE
fix: vehicle fines and insurance sync timeouts and crashes

### DIFF
--- a/csf_tz/csf_tz/doctype/latra_licenses/__init__.py
+++ b/csf_tz/csf_tz/doctype/latra_licenses/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026, Aakvatech and contributors
+# For license information, please see license.txt

--- a/csf_tz/csf_tz/doctype/latra_licenses/latra_licenses.json
+++ b/csf_tz/csf_tz/doctype/latra_licenses/latra_licenses.json
@@ -1,0 +1,116 @@
+{
+ "actions": [],
+ "autoname": "field:license_number",
+ "creation": "2026-06-12 00:00:00.000000",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "vehicle",
+  "license_number",
+  "license_status",
+  "license_type",
+  "service_type",
+  "column_break_1",
+  "place_issued",
+  "issue_date",
+  "expire_date"
+ ],
+ "fields": [
+  {
+   "fieldname": "vehicle",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Vehicle",
+   "read_only": 1
+  },
+  {
+   "fieldname": "license_number",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "License Number",
+   "read_only": 1,
+   "reqd": 1,
+   "unique": 1
+  },
+  {
+   "fieldname": "license_status",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "License Status",
+   "read_only": 1
+  },
+  {
+   "fieldname": "license_type",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "License Type",
+   "read_only": 1
+  },
+  {
+   "fieldname": "service_type",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Service Type",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_1",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "place_issued",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Place Issued",
+   "read_only": 1
+  },
+  {
+   "fieldname": "issue_date",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "label": "Issue Date",
+   "read_only": 1
+  },
+  {
+   "fieldname": "expire_date",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Expire Date",
+   "read_only": 1
+  }
+ ],
+ "links": [],
+ "modified": "2026-06-12 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "CSF TZ",
+ "name": "Latra Licenses",
+ "naming_rule": "By fieldname",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "expire_date",
+ "sort_order": "DESC",
+ "states": [],
+ "title_field": "vehicle",
+ "track_changes": 0
+}

--- a/csf_tz/csf_tz/doctype/latra_licenses/latra_licenses.py
+++ b/csf_tz/csf_tz/doctype/latra_licenses/latra_licenses.py
@@ -1,0 +1,600 @@
+# Copyright (c) 2026, Aakvatech and contributors
+# For license information, please see license.txt
+
+from __future__ import unicode_literals
+
+from time import sleep
+
+import frappe
+import requests
+from frappe.model.document import Document
+
+from csf_tz.vehicle_authority import get_vehicle_like_records
+from csf_tz.csf_tz.doctype.vehicle_fine_record.vehicle_fine_record import (
+	is_valid_number_plate,
+	normalize_number_plate,
+)
+
+LATRA_GQL_URL = "https://rrims.latra.go.tz:8086/graphql"
+LATRA_LOGIN_URL = "https://rrims.latra.go.tz:8086/user/login"
+LATRA_BASIC_AUTH = "Basic bGFsaXM6MTIzNDU2Nzg="
+TOKEN_EXPIRED = "TOKEN_EXPIRED"
+
+GQL_QUERY = """
+query findMyCurrentLicensesPageable($pageableParam: PageableParamInput){
+  findMyCurrentLicensesPageable(pageableParam: $pageableParam){
+    content{
+      licenseNumber
+      licenseStatus
+      validFrom
+      validTo
+      serviceType {
+        name
+        licenseType { licenseTypeName }
+      }
+      licenseInfoDetail {
+        currentLicenseApplication {
+          branch { name district { districtName } }
+        }
+      }
+      vehicle{ vehicleRegistrationNumber }
+    }
+  }
+}
+"""
+
+OFFENCE_GQL_QUERY = """
+query allMyClientOffencesPageable($pageableParam: PageableParamInput) {
+  allMyClientOffencesPageable(pageableParam: $pageableParam) {
+    content {
+      uid
+      vehicleRegistrationNumber
+      offenceReferenceNumber
+      offenderName
+      offenceDate
+      paymentStatus
+      amount
+      clientOffenceType
+      warningDescription
+      comment
+      offence { uid name code compoundedAmount }
+      offenceLocation { uid name }
+    }
+    totalElements
+  }
+}
+"""
+
+
+class LatraLicenses(Document):
+	pass
+
+
+@frappe.whitelist()
+def update_latra_records():
+	"""
+	Scheduler entry point. Discovers all vehicle-like records, deduplicates
+	the plates, and dispatches a background job for each unique plate.
+	"""
+	seen_plates = set()
+	enqueued = 0
+	skipped = 0
+	invalid_plates = []
+
+	vehicles = list(get_vehicle_like_records())
+	frappe.logger().info(f"[LATRA] Found {len(vehicles)} total vehicle records")
+
+	for vehicle in vehicles:
+		plate = normalize_number_plate(vehicle.plate_number)
+
+		if not plate:
+			frappe.logger().warning(f"[LATRA] Could not normalize plate: {vehicle.plate_number}")
+			invalid_plates.append(vehicle.plate_number)
+			skipped += 1
+			continue
+
+		if not is_valid_number_plate(plate):
+			frappe.logger().warning(f"[LATRA] Invalid plate format: {plate}")
+			invalid_plates.append(plate)
+			skipped += 1
+			continue
+
+		if plate in seen_plates:
+			skipped += 1
+			continue
+
+		seen_plates.add(plate)
+
+		frappe.enqueue(
+			"csf_tz.csf_tz.doctype.latra_licenses.latra_licenses.fetch_and_update_latra_license",
+			plate_number=plate,
+			queue="long",
+		)
+		enqueued += 1
+
+	frappe.logger().info(
+		f"[LATRA] Enqueued {enqueued} licenses, skipped {skipped}, "
+		f"invalid plates: {len(invalid_plates)} - {invalid_plates[:10]}"
+	)
+	try:
+		offence_result = update_latra_offences()
+	except Exception:
+		offence_result = None
+		frappe.log_error(
+			title="LATRA: Offence Sync Failed",
+			message=frappe.get_traceback(),
+		)
+
+	return {
+		"message": f"Enqueued license updates for {enqueued} vehicles",
+		"skipped": skipped,
+		"invalid_plates": invalid_plates[:20],
+		"offences": offence_result,
+	}
+
+
+@frappe.whitelist()
+def update_latra_offences():
+	plates = {
+		plate
+		for plate in (normalize_number_plate(v.plate_number) for v in get_vehicle_like_records())
+		if plate and is_valid_number_plate(plate)
+	}
+	token = _get_token()
+	if not token:
+		frappe.log_error(title="LATRA: No Token", message="Set access_token in Latra Settings.")
+		return
+
+	data = _call_offences_graphql(token)
+	if data == TOKEN_EXPIRED:
+		new_token = _refresh_token(token)
+		data = _call_offences_graphql(new_token) if new_token else None
+	if not data:
+		frappe.log_error(title="LATRA: Offence GraphQL Failed", message="Could not fetch LATRA offences.")
+		return
+
+	saved = skipped = 0
+	for row in ((data.get("allMyClientOffencesPageable") or {}).get("content") or []):
+		plate = normalize_number_plate(row.get("vehicleRegistrationNumber"))
+		if not plate or plate not in plates:
+			skipped += 1
+			continue
+
+		offence = row.get("offence") or {}
+		location = row.get("offenceLocation") or {}
+		values = {
+			"mv_reg_number": plate,
+			"offender_name": row.get("offenderName") or "",
+			"offence_type": row.get("clientOffenceType") or "",
+			"status": row.get("paymentStatus") or "",
+			"offence": offence.get("name") or row.get("warningDescription") or "",
+			"offence_date": _parse_date(row.get("offenceDate")),
+			"location": location.get("name") or "",
+			"reference_number": row.get("offenceReferenceNumber") or row.get("uid") or "",
+			"amount": row.get("amount") or offence.get("compoundedAmount") or 0,
+		}
+		existing = frappe.db.get_value(
+			"Latra Offence",
+			{
+				"mv_reg_number": values["mv_reg_number"],
+				"reference_number": values["reference_number"],
+				"offence_date": values["offence_date"],
+				"offence": values["offence"],
+			},
+			"name",
+		)
+		if existing:
+			frappe.db.set_value("Latra Offence", existing, values)
+		else:
+			frappe.get_doc({"doctype": "Latra Offence", **values}).insert(ignore_permissions=True)
+		saved += 1
+
+	return {"saved": saved, "skipped": skipped}
+
+
+def fetch_and_update_latra_license(plate_number):
+	"""
+	Background job. Fetches the LATRA GraphQL response for the given plate
+	and upserts the results into Latra Licenses.
+	"""
+	frappe.logger().info(f"[LATRA] Starting fetch for plate: {plate_number}")
+
+	token = _get_token()
+	if not token:
+		frappe.log_error(
+			title="LATRA: No Token",
+			message="Set access_token in Latra Settings before running LATRA sync.",
+		)
+		return
+
+	data = _call_graphql(token, plate_number)
+	if data == TOKEN_EXPIRED:
+		frappe.logger().info(f"[LATRA] Token expired for {plate_number}, refreshing...")
+		new_token = _refresh_token(token)
+		if not new_token:
+			frappe.log_error(
+				title="LATRA: Token Refresh Failed",
+				message=f"Could not refresh token for {plate_number}",
+			)
+			return
+		data = _call_graphql(new_token, plate_number)
+		if data in (None, TOKEN_EXPIRED):
+			frappe.log_error(
+				title="LATRA: GraphQL Call Failed After Token Refresh",
+				message=f"Still failed for {plate_number}",
+			)
+			return
+	elif data is None:
+		frappe.log_error(
+			title="LATRA: GraphQL Call Failed",
+			message=f"Got None response for {plate_number}",
+		)
+		return
+
+	licenses = (
+		(data.get("findMyCurrentLicensesPageable") or {}).get("content") or []
+	)
+
+	frappe.logger().info(f"[LATRA] Got {len(licenses)} licenses for {plate_number}")
+
+	if not licenses:
+		frappe.logger().warning(f"[LATRA] No licenses found in LATRA for {plate_number}")
+		return
+
+	matching_licenses = []
+	for lic in licenses:
+		vehicle_reg = normalize_number_plate(
+			(lic.get("vehicle") or {}).get("vehicleRegistrationNumber")
+		)
+		license_status = (lic.get("licenseStatus") or "").strip().upper()
+		if vehicle_reg == plate_number and license_status == "ACTIVE":
+			matching_licenses.append(lic)
+
+	if not matching_licenses:
+		frappe.logger().warning(f"[LATRA] No ACTIVE license found for {plate_number}")
+		return
+
+	matching_licenses.sort(key=lambda d: str(d.get("validTo") or ""), reverse=True)
+
+	records_saved = 0
+	for lic in matching_licenses[:1]:
+		try:
+			license_number = lic.get("licenseNumber")
+			if not license_number:
+				frappe.logger().warning(f"[LATRA] No license number for {plate_number}")
+				continue
+
+			values = {
+				"vehicle": plate_number,
+				"license_number": license_number,
+				"license_status": lic.get("licenseStatus") or "",
+				"license_type": _get_license_type(lic),
+				"service_type": (lic.get("serviceType") or {}).get("name") or "",
+				"place_issued": _get_place_issued(lic),
+				"issue_date": _parse_date(lic.get("validFrom")),
+				"expire_date": _parse_date(lic.get("validTo")),
+			}
+
+			if frappe.db.exists("Latra Licenses", license_number):
+				frappe.db.set_value("Latra Licenses", license_number, values)
+				frappe.logger().info(
+					f"[LATRA] Updated license {license_number} for {plate_number}"
+				)
+				records_saved += 1
+			else:
+				try:
+					doc = frappe.get_doc({"doctype": "Latra Licenses", **values})
+					doc.insert(ignore_permissions=True)
+					frappe.logger().info(
+						f"[LATRA] Inserted license {license_number} for {plate_number}"
+					)
+					records_saved += 1
+				except frappe.exceptions.DuplicateEntryError:
+					frappe.logger().warning(
+						f"[LATRA] Duplicate entry for {license_number}"
+					)
+				except Exception:
+					frappe.log_error(
+						title=f"LATRA: Error saving license {license_number} for {plate_number}",
+						message=frappe.get_traceback(),
+					)
+
+		except Exception:
+			frappe.log_error(
+				title=f"LATRA: Error processing license for {plate_number}",
+				message=frappe.get_traceback(),
+			)
+
+	frappe.logger().info(
+		f"[LATRA] Completed for {plate_number}: {records_saved} records saved"
+	)
+
+
+def _get_token():
+	try:
+		cached_token = frappe.cache().get_value(_token_cache_key(), expires=True)
+		if cached_token:
+			return str(cached_token).strip()
+
+		token = (frappe.db.get_single_value("Latra Settings", "access_token") or "").strip()
+		if token:
+			frappe.cache().set_value(_token_cache_key(), token, expires_in_sec=60 * 60 * 8)
+			frappe.logger().debug("[LATRA] Using existing token")
+		else:
+			frappe.logger().warning("[LATRA] No token found in settings")
+		return token
+	except Exception as e:
+		frappe.log_error(
+			title="LATRA: Error reading token",
+			message=str(e),
+		)
+		return None
+
+
+def _refresh_token(old_token=None):
+	"""
+	Log in to the LATRA API using stored credentials and save the new token.
+	Returns the new token string, or None on failure.
+	"""
+	lock = frappe.cache().lock(
+		f"{frappe.local.site}:latra_token_refresh",
+		timeout=120,
+		blocking_timeout=60,
+	)
+	with lock:
+		current_token = _get_token()
+		if old_token and current_token and current_token != old_token:
+			return current_token
+		return _refresh_token_locked()
+
+
+def _refresh_token_locked():
+	try:
+		settings = frappe.get_single("Latra Settings")
+		email = (settings.get("username") or "").strip()
+		try:
+			password = (settings.get_password("password") or "").strip()
+		except Exception:
+			password = (settings.get("password") or "").strip()
+	except Exception:
+		frappe.log_error(
+			title="LATRA: Settings missing",
+			message=frappe.get_traceback(),
+		)
+		return None
+
+	if not email or not password:
+		frappe.log_error(
+			title="LATRA: Credentials missing",
+			message="Username or password not set in Latra Settings",
+		)
+		return None
+
+	try:
+		frappe.logger().info("[LATRA] Attempting token refresh...")
+		response = requests.post(
+			LATRA_LOGIN_URL,
+			data={"username": email, "password": password},
+			headers={
+				"Authorization": LATRA_BASIC_AUTH,
+				"Content-Type": "application/x-www-form-urlencoded",
+				"Accept": "application/json",
+			},
+			timeout=30,
+		)
+		if response.status_code >= 400:
+			frappe.log_error(
+				title="LATRA: Token refresh HTTP failed",
+				message=f"HTTP {response.status_code}: {response.text[:1000]}",
+			)
+			return None
+		ld = response.json() if response.text else {}
+		d = ld.get("data") if isinstance(ld.get("data"), dict) else {}
+		new_token = (
+			ld.get("token")
+			or ld.get("accessToken")
+			or ld.get("access_token")
+			or d.get("token")
+			or d.get("accessToken")
+			or d.get("access_token")
+			or ""
+		).strip()
+	except Exception:
+		frappe.log_error(
+			title="LATRA: Token refresh failed",
+			message=frappe.get_traceback(),
+		)
+		return None
+
+	if new_token:
+		frappe.db.set_single_value("Latra Settings", "access_token", new_token)
+		frappe.cache().set_value(_token_cache_key(), new_token, expires_in_sec=60 * 60 * 8)
+		frappe.logger().info("[LATRA] Token refreshed successfully")
+	else:
+		frappe.log_error(
+			title="LATRA: No token in login response",
+			message=f"Response: {ld}",
+		)
+
+	return new_token or None
+
+
+def _token_cache_key():
+	return f"{frappe.local.site}:latra_access_token"
+
+
+def _call_offences_graphql(token):
+	payload = {
+		"operationName": "allMyClientOffencesPageable",
+		"variables": {
+			"pageableParam": {
+				"first": 0,
+				"size": 500,
+				"sortBy": "id",
+				"sortDirection": "DESC",
+				"searchFields": [],
+			}
+		},
+		"query": OFFENCE_GQL_QUERY,
+	}
+	response = requests.post(
+		LATRA_GQL_URL,
+		json=payload,
+		headers={
+			"Authorization": f"Bearer {token}",
+			"Accept": "application/json",
+			"Content-Type": "application/json",
+		},
+		timeout=60,
+	)
+	if response.status_code == 401:
+		return TOKEN_EXPIRED
+	response.raise_for_status()
+	result = response.json()
+	if result.get("errors"):
+		frappe.log_error(
+			title="LATRA Offence GraphQL Error",
+			message=frappe.as_json(result.get("errors"))[:2000],
+		)
+		return None
+	return result.get("data")
+
+
+def _call_graphql(token, plate_number):
+	"""
+	POST to the LATRA GraphQL endpoint. Returns the parsed `data` dict on
+	success, TOKEN_EXPIRED on a 401, or None on any other failure.
+	"""
+	payload = {
+		"operationName": "findMyCurrentLicensesPageable",
+		"variables": {
+			"pageableParam": {
+				"first": 0,
+				"size": 200,
+				"sortBy": "id",
+				"sortDirection": "DESC",
+				"searchFields": [],
+			}
+		},
+		"query": GQL_QUERY,
+	}
+	headers = {
+		"Authorization": f"Bearer {token}",
+		"Accept": "application/json",
+		"Content-Type": "application/json",
+	}
+
+	max_retries = 3
+	response = None
+
+	for attempt in range(max_retries):
+		try:
+			if attempt > 0:
+				frappe.logger().info(f"[LATRA] Retry {attempt}/{max_retries-1} for {plate_number}")
+				sleep(5 * attempt)
+
+			response = requests.post(
+				LATRA_GQL_URL, json=payload, headers=headers, timeout=30
+			)
+
+			if response.status_code == 401:
+				frappe.logger().warning(f"[LATRA] 401 Unauthorized for {plate_number}")
+				return TOKEN_EXPIRED
+
+			response.raise_for_status()
+			frappe.logger().debug(f"[LATRA] GraphQL success for {plate_number}")
+			break
+
+		except (requests.exceptions.Timeout, requests.exceptions.ConnectionError) as e:
+			if attempt < max_retries - 1:
+				frappe.logger().warning(
+					f"[LATRA] Connection error (attempt {attempt+1}/{max_retries}): {str(e)}"
+				)
+				continue
+			frappe.logger().error(
+				f"[LATRA] Connection timeout for {plate_number} after {max_retries} retries: {str(e)}"
+			)
+			return None
+
+		except requests.exceptions.HTTPError:
+			status = response.status_code if response is not None else 0
+			if status in (408, 429) or status >= 500:
+				if attempt < max_retries - 1:
+					frappe.logger().warning(
+						f"[LATRA] HTTP {status} (attempt {attempt+1}/{max_retries}), will retry"
+					)
+					continue
+				frappe.logger().error(
+					f"[LATRA] HTTP {status} for {plate_number} after {max_retries} retries"
+				)
+				return None
+			else:
+				response_text = response.text[:500] if response else ""
+				frappe.log_error(
+					title="LATRA API Error",
+					message=f"HTTP {status} for {plate_number}: {response_text}",
+				)
+				return None
+
+		except requests.exceptions.RequestException as e:
+			frappe.log_error(title="LATRA API Error", message=str(e))
+			return None
+
+	if response is None:
+		frappe.log_error(
+			title="LATRA: No Response",
+			message=f"No response for {plate_number}",
+		)
+		return None
+
+	try:
+		result = response.json()
+		data = result.get("data")
+
+		errors = result.get("errors")
+		if errors:
+			frappe.log_error(
+				title="LATRA GraphQL Error",
+				message=f"GraphQL errors for {plate_number}: {errors}",
+			)
+			return None
+
+		return data
+	except Exception:
+		frappe.log_error(
+			title="LATRA API: Invalid JSON",
+			message=f"Non-JSON response for {plate_number}: {response.text[:500] if response else 'No response'}",
+		)
+		return None
+
+
+def _parse_date(value):
+	if not value:
+		return None
+	try:
+		return str(value)[:10] if "T" in str(value) else str(value)
+	except Exception:
+		return None
+
+
+def _get_place_issued(license_row):
+	branch = (
+		((license_row.get("licenseInfoDetail") or {}).get("currentLicenseApplication") or {})
+		.get("branch")
+		or {}
+	)
+	district = branch.get("district") or {}
+	branch_name = branch.get("name") or ""
+	district_name = district.get("districtName") or ""
+	return f"{branch_name} ({district_name})" if branch_name and district_name else branch_name
+
+
+def _get_license_type(license_row):
+	license_type = (
+		((license_row.get("serviceType") or {}).get("licenseType") or {}).get("licenseTypeName")
+	) or ""
+	return {
+		"GOODSCARRYINGVEHICLE": "GCV",
+		"PUBLICSERVICEVEHICLE": "PSV",
+		"PRIVATEHIRE": "Private Hire",
+	}.get(license_type, license_type)

--- a/csf_tz/csf_tz/doctype/latra_offence/__init__.py
+++ b/csf_tz/csf_tz/doctype/latra_offence/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026, Aakvatech and contributors
+# For license information, please see license.txt

--- a/csf_tz/csf_tz/doctype/latra_offence/latra_offence.json
+++ b/csf_tz/csf_tz/doctype/latra_offence/latra_offence.json
@@ -1,0 +1,131 @@
+{
+ "actions": [],
+ "autoname": "hash",
+ "creation": "2026-06-15 00:00:00.000000",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "mv_reg_number",
+  "offender_name",
+  "column_break_1",
+  "offence_type",
+  "status",
+  "offence_section",
+  "offence",
+  "offence_date",
+  "location",
+  "column_break_2",
+  "reference_number",
+  "amount"
+ ],
+ "fields": [
+  {
+   "fieldname": "mv_reg_number",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "MV Reg Number",
+   "read_only": 1
+  },
+  {
+   "fieldname": "offender_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Offender Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_1",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "offence_type",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Offence Type",
+   "read_only": 1
+  },
+  {
+   "fieldname": "status",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Status",
+   "read_only": 1
+  },
+  {
+   "fieldname": "offence_section",
+   "fieldtype": "Section Break",
+   "label": "Offence Details"
+  },
+  {
+   "fieldname": "offence",
+   "fieldtype": "Text",
+   "in_list_view": 1,
+   "label": "Offence",
+   "read_only": 1
+  },
+  {
+   "fieldname": "offence_date",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Offence Date",
+   "read_only": 1
+  },
+  {
+   "fieldname": "location",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Location",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_2",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "reference_number",
+   "fieldtype": "Data",
+   "in_standard_filter": 1,
+   "label": "Reference Number",
+   "read_only": 1
+  },
+  {
+   "fieldname": "amount",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Amount",
+   "read_only": 1
+  }
+ ],
+ "links": [],
+ "modified": "2026-06-15 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "CSF TZ",
+ "name": "Latra Offence",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "offence_date",
+ "sort_order": "DESC",
+ "states": [],
+ "title_field": "mv_reg_number",
+ "track_changes": 0
+}

--- a/csf_tz/csf_tz/doctype/latra_offence/latra_offence.py
+++ b/csf_tz/csf_tz/doctype/latra_offence/latra_offence.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, Aakvatech and contributors
+# For license information, please see license.txt
+
+from frappe.model.document import Document
+
+
+class LatraOffence(Document):
+	pass

--- a/csf_tz/csf_tz/doctype/latra_settings/__init__.py
+++ b/csf_tz/csf_tz/doctype/latra_settings/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2026, Aakvatech and contributors

--- a/csf_tz/csf_tz/doctype/latra_settings/latra_settings.json
+++ b/csf_tz/csf_tz/doctype/latra_settings/latra_settings.json
@@ -1,0 +1,56 @@
+{
+ "actions": [],
+ "creation": "2026-06-12 00:00:00.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "username",
+  "password",
+  "access_token"
+ ],
+ "fields": [
+  {
+   "fieldname": "username",
+   "fieldtype": "Data",
+   "label": "Username",
+   "reqd": 1
+  },
+  {
+   "fieldname": "password",
+   "fieldtype": "Password",
+   "label": "Password",
+   "reqd": 1
+  },
+  {
+   "fieldname": "access_token",
+   "fieldtype": "Data",
+   "label": "Access Token",
+   "description": "Auto-refreshed by the sync scheduler. Do not edit manually."
+  }
+ ],
+ "issingle": 1,
+ "links": [],
+ "modified": "2026-06-12 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "CSF TZ",
+ "name": "Latra Settings",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "track_changes": 0
+}

--- a/csf_tz/csf_tz/doctype/latra_settings/latra_settings.py
+++ b/csf_tz/csf_tz/doctype/latra_settings/latra_settings.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, Aakvatech and contributors
+# For license information, please see license.txt
+
+from frappe.model.document import Document
+
+
+class LatraSettings(Document):
+	pass

--- a/csf_tz/csf_tz/doctype/tz_insurance_cover_note/tz_insurance_cover_note.py
+++ b/csf_tz/csf_tz/doctype/tz_insurance_cover_note/tz_insurance_cover_note.py
@@ -6,7 +6,13 @@ import requests
 import json
 from datetime import datetime
 from frappe.utils import cint
+from time import sleep
 from frappe.model.document import Document
+from csf_tz.vehicle_authority import get_vehicle_like_records
+from csf_tz.csf_tz.doctype.vehicle_fine_record.vehicle_fine_record import (
+	normalize_number_plate,
+	is_valid_number_plate,
+)
 
 class TZInsuranceCoverNote(Document):
 	pass
@@ -19,87 +25,109 @@ def update_covernote_docs():
 	Forexample:
 		for June: a routine will run on 00:00 am, June 1, 2022
 	"""
+	seen_plates = set()
+	enqueued = 0
 
-	motor_vehicles = frappe.get_all('Vehicle', 'name')
-	
-	for vehicle in motor_vehicles:
-		req = get_covernote_details(vehicle.name)
-		try:
-			for record in req.get('data'):
-				if not frappe.db.exists('TZ Insurance Cover Note', record['coverNoteNumber']):
-					doc = frappe.new_doc('TZ Insurance Cover Note')
-				else:
-					doc = frappe.get_doc('TZ Insurance Cover Note', record['coverNoteNumber'])
-				
-				for key, value in record.items():
-					
-					if key.lower() == 'motor':
-						row = {}
-						doc.insurance_motors = []
-						for motor_child_key, motor_child_value in value.items():
-							motor_new_value = None
-							if motor_child_value and motor_child_key.lower() in ['createddate', 'updateddate']:
-								unix_timestamp_int = cint(motor_child_value)
-								motor_new_value = datetime.utcfromtimestamp((unix_timestamp_int/1000)).strftime('%Y-%m-%d %H:%M:%S')
-							else:
-								motor_new_value = motor_child_value
-							
-							row[motor_child_key.lower()] = motor_new_value
+	for vehicle in get_vehicle_like_records():
+		plate = normalize_number_plate(vehicle.plate_number)
+		if not plate or not is_valid_number_plate(plate):
+			continue
+		if plate in seen_plates:
+			continue
+		seen_plates.add(plate)
+
+		frappe.enqueue(
+			"csf_tz.csf_tz.doctype.tz_insurance_cover_note.tz_insurance_cover_note.fetch_and_update_covernote",
+			plate_number=plate,
+			queue="long",
+		)
+		enqueued += 1
+
+	frappe.logger().info(f"[CoverNote] Enqueued covernote updates for {enqueued} vehicles")
+	return {"message": f"Enqueued covernote updates for {enqueued} vehicles"}
+
+def fetch_and_update_covernote(plate_number):
+	"""
+	Background job to fetch and update covernote for a specific vehicle plate.
+	"""
+	req = get_covernote_details(plate_number)
+	try:
+		if not req or not req.get('data'):
+			return
+
+		for record in req.get('data'):
+			if not frappe.db.exists('TZ Insurance Cover Note', record['coverNoteNumber']):
+				doc = frappe.new_doc('TZ Insurance Cover Note')
+			else:
+				doc = frappe.get_doc('TZ Insurance Cover Note', record['coverNoteNumber'])
+			
+			for key, value in record.items():
+				if key.lower() == 'motor':
+					row = {}
+					doc.insurance_motors = []
+					for motor_child_key, motor_child_value in value.items():
+						motor_new_value = None
+						if motor_child_value and motor_child_key.lower() in ['createddate', 'updateddate']:
+							unix_timestamp_int = cint(motor_child_value)
+							motor_new_value = datetime.utcfromtimestamp((unix_timestamp_int/1000)).strftime('%Y-%m-%d %H:%M:%S')
+						else:
+							motor_new_value = motor_child_value
 						
-						doc.append('insurance_motors', row)
+						row[motor_child_key.lower()] = motor_new_value
 					
-					if key.lower() == 'company':
-						row = {}
-						doc.insurance_provider = []
-						for company_child_key, company_child_value in value.items():
-							company_new_value = None
-							if company_child_value and company_child_key.lower() in ['createddate', 'updateddate', 'incorporationdate', 'initialregistrationdate', 'businesscommencementdate']:
-								unix_timestamp_int = cint(company_child_value)
-								company_new_value = datetime.utcfromtimestamp((unix_timestamp_int/1000)).strftime('%Y-%m-%d %H:%M:%S')
-							
-							elif company_child_key.lower() == 'shareholders':
-								company_new_value = json.dumps(company_child_value)
+					doc.append('insurance_motors', row)
+				
+				if key.lower() == 'company':
+					row = {}
+					doc.insurance_provider = []
+					for company_child_key, company_child_value in value.items():
+						company_new_value = None
+						if company_child_value and company_child_key.lower() in ['createddate', 'updateddate', 'incorporationdate', 'initialregistrationdate', 'businesscommencementdate']:
+							unix_timestamp_int = cint(company_child_value)
+							company_new_value = datetime.utcfromtimestamp((unix_timestamp_int/1000)).strftime('%Y-%m-%d %H:%M:%S')
+						
+						elif company_child_key.lower() == 'shareholders':
+							company_new_value = json.dumps(company_child_value)
+						
+						else:
+							company_new_value = company_child_value
+						
+						row[company_child_key.lower()] = company_new_value
+						
+					doc.append('insurance_provider', row)
+				
+				if key.lower() == 'policyholders':
+					doc.policy_holders = []
+					for i, row in enumerate(value):
+						new_row = {}
+						for policy_child_key, policy_child_value in row.items():
+							policy_new_value = None
+							if policy_child_value and policy_child_key.lower() in ['createddate', 'updateddate', 'policyholderbirthdate']:
+								unix_timestamp_int = cint(policy_child_value)
+								policy_new_value = datetime.utcfromtimestamp((unix_timestamp_int/1000)).strftime('%Y-%m-%d %H:%M:%S')
 							
 							else:
-								company_new_value = company_child_value
-							
-							row[company_child_key.lower()] = company_new_value
-							
-						doc.append('insurance_provider', row)
-					
-					if key.lower() == 'policyholders':
-						doc.policy_holders = []
-						for i, row in enumerate(value):
-							new_row = {}
-							for policy_child_key, policy_child_value in row.items():
-								policy_new_value = None
-								if policy_child_value and policy_child_key.lower() in ['createddate', 'updateddate', 'policyholderbirthdate']:
-									unix_timestamp_int = cint(policy_child_value)
-									policy_new_value = datetime.utcfromtimestamp((unix_timestamp_int/1000)).strftime('%Y-%m-%d %H:%M:%S')
-								
-								else:
-									policy_new_value = policy_child_value
-							
-								new_row[policy_child_key.lower()] = policy_new_value
-							
-							doc.append('policy_holders', new_row)
-					
-					if key.lower() not in ['covernotestartdate', 'covernoteenddate', 'company', 'motor', 'policyholders']:
-						doc.update({key.lower(): value})
-					
-					if key.lower() in ['covernotestartdate', 'covernoteenddate']:
-						unix_timestamp_int = cint(value)
-						date_value = datetime.utcfromtimestamp((unix_timestamp_int/1000.0)).strftime('%Y-%m-%d %H:%M:%S')
-						doc.update({key.lower(): date_value})
-					
-				doc.vehicle = vehicle.name
-				doc.save(ignore_permissions=True)
-		
-		except Exception as e:
-			frappe.log_error(frappe.get_traceback(), str(e))
+								policy_new_value = policy_child_value
+						
+							new_row[policy_child_key.lower()] = policy_new_value
+						
+						doc.append('policy_holders', new_row)
+				
+				if key.lower() not in ['covernotestartdate', 'covernoteenddate', 'company', 'motor', 'policyholders']:
+					doc.update({key.lower(): value})
+				
+				if key.lower() in ['covernotestartdate', 'covernoteenddate']:
+					unix_timestamp_int = cint(value)
+					date_value = datetime.utcfromtimestamp((unix_timestamp_int/1000.0)).strftime('%Y-%m-%d %H:%M:%S')
+					doc.update({key.lower(): date_value})
+				
+			doc.vehicle = plate_number
+			doc.save(ignore_permissions=True)
 	
-	frappe.db.commit()
-	return True
+		frappe.db.commit()
+	
+	except Exception as e:
+		frappe.log_error(frappe.get_traceback(), str(e))
 
 def get_covernote_details(regnumber):
 	"""Fetch motor insurance details from tira
@@ -109,22 +137,62 @@ def get_covernote_details(regnumber):
 	url = "https://tiramis.tira.go.tz/covernote/api/public/portal/verify"
 
 	payload = json.dumps({
-        "paramType": 2,
-        "searchParam": regnumber
-    })
+		"paramType": 2,
+		"searchParam": regnumber
+	})
 	headers = {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json'
-    }
+		'Accept': 'application/json',
+		'Content-Type': 'application/json'
+	}
+
+	max_retries = 3
+	response = None
+
+	for attempt in range(max_retries):
+		try:
+			if attempt > 0:
+				sleep(5 * attempt)
+
+			response = requests.post(url, headers=headers, data=payload, timeout=30, verify=False)
+			response.raise_for_status()
+			break
+
+		except (requests.exceptions.Timeout, requests.exceptions.ConnectionError):
+			if attempt < max_retries - 1:
+				continue
+			frappe.logger().warning(f"[CoverNote] Connection timeout for {regnumber} after {max_retries} retries")
+			return None
+
+		except requests.exceptions.HTTPError:
+			status = response.status_code if response is not None else 0
+			if status in (408, 429) or status >= 500:
+				if attempt < max_retries - 1:
+					continue
+				frappe.logger().warning(f"[CoverNote] HTTP {status} for {regnumber} after {max_retries} retries")
+				return None
+			else:
+				frappe.log_error(
+					title="Tiramis API Error",
+					message=f"HTTP {status} for {regnumber}: {response.text[:500] if response is not None else ''}"
+				)
+				return None
+
+		except requests.exceptions.RequestException as e:
+			frappe.log_error(title="Tiramis API Error", message=str(e))
+			return None
+
+	if response is None:
+		return None
 
 	try:
-		response = requests.post(url, headers=headers, data=payload, timeout=3000, verify=False)
 		if response.status_code == 200:
-			return json.loads(response.text)
+			return response.json()
 		else:
 			frappe.log_error(response.text, str(response.status_code))
-
-	except Exception as e:
-		frappe.log_error(frappe.get_traceback(), str(e))
-
-
+			return None
+	except Exception:
+		frappe.log_error(
+			title="Tiramis API: Invalid JSON",
+			message=f"Non-JSON response for {regnumber}: {response.text[:500]}"
+		)
+		return None

--- a/csf_tz/csf_tz/doctype/vehicle_fine_record/vehicle_fine_record.py
+++ b/csf_tz/csf_tz/doctype/vehicle_fine_record/vehicle_fine_record.py
@@ -3,136 +3,154 @@
 # For license information, please see license.txt
 
 from __future__ import unicode_literals
+import base64
 from frappe.model.document import Document
 import frappe
-from frappe import _
-import requests
-from requests.exceptions import Timeout
-from bs4 import BeautifulSoup
-from csf_tz.custom_api import print_out
-import re
+from frappe.utils import flt
+import hashlib
 import json
+import requests
+from csf_tz.custom_api import print_out
+from csf_tz.vehicle_authority import get_vehicle_docname_by_plate, get_vehicle_like_records
+import re
 from time import sleep
+from cryptography.hazmat.primitives import padding
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+
+TPF_SECRET = "irtismutDkjQBbZKEUn8hw7WqKdxld01E6HIY"
 
 
 class VehicleFineRecord(Document):
     def validate(self):
         """
-        Validate the vehicle number plate and get the vehicle name
+        Resolve the ERPNext Vehicle document linked to this fine's plate number.
 
-        1. Check if the vehicle number plate is valid
-        2. Get the vehicle name from the vehicle number plate
-        3. If the vehicle name is not found, set the vehicle name as the vehicle number plate
+        Searches all known plate-like fields (license_plate, number_plate, etc.)
+        across the Vehicle doctype. If found, sets vehicle_doc; otherwise clears it.
         """
         try:
             if self.vehicle:
-                vehicle_name = frappe.get_value(
-                    "Vehicle", {"number_plate": self.vehicle}, "name"
-                ) or frappe.get_value("Vehicle", {"license_plate": self.vehicle}, "name")
-                if vehicle_name:
-                    self.vehicle_doc = vehicle_name
-                else:
-                    self.vehicle_doc = self.vehicle
-        except Exception as e:
+                vehicle_name = get_vehicle_docname_by_plate(self.vehicle)
+                self.vehicle_doc = vehicle_name or None
+        except Exception:
             frappe.log_error(
-                title=f"Error in VehicleFineRecord.validate",
+                title="Error in VehicleFineRecord.validate",
                 message=frappe.get_traceback(),
             )
 
 
-def check_fine_all_vehicles(batch_size=20):
-    plate_list = frappe.get_all(
-        "Vehicle", fields=["name", "number_plate", "license_plate"], limit_page_length=0
-    )
-    total_vehicles = len(plate_list)
+def normalize_number_plate(number_plate):
+    """
+    Strip non-alphanumeric characters and uppercase the result.
+    Returns None if the input is empty or normalises to an empty string.
+    Truncates to 7 characters (Tanzanian plate length).
+    """
+    if not number_plate:
+        return None
+    normalized = re.sub(r"[^A-Za-z0-9]", "", str(number_plate)).upper()
+    normalized = normalized[:7] if len(normalized) >= 7 else normalized
+    return normalized or None
 
-    # Enqueue get_fine calls in the background for each vehicle
-    for vehicle in plate_list:
+
+def is_valid_number_plate(number_plate):
+    """
+    Validate the plate follows the Tanzanian format: 1-3 letters, 3 digits, 1-3 letters.
+    Example: T123ABC, TZ999A
+    """
+    if not number_plate or len(number_plate) != 7:
+        return False
+    return bool(re.match(r"^[A-Z]{1,3}[0-9]{3}[A-Z]{1,3}$", number_plate))
+
+
+def decode_tpf_response(result):
+    if not result.get("payload"):
+        return result
+
+    payload = str(result.get("payload")).strip()
+    try:
+        maybe_payload = base64.b64decode(payload, validate=True).decode()
+        if re.match(r"^[A-Za-z0-9+/]+=*$", maybe_payload.strip()):
+            payload = maybe_payload.strip()
+    except Exception:
+        pass
+
+    key = TPF_SECRET[:32].ljust(32, "\0").encode()
+    iv = hashlib.sha256(TPF_SECRET.encode()).hexdigest()[:16].encode()
+    decryptor = Cipher(algorithms.AES(key), modes.CBC(iv)).decryptor()
+    padded = decryptor.update(base64.b64decode(payload)) + decryptor.finalize()
+    unpadder = padding.PKCS7(128).unpadder()
+    plain = unpadder.update(padded) + unpadder.finalize()
+    return json.loads(plain.decode("utf-8"))
+
+
+def check_fine_all_vehicles(batch_size=20):
+    """
+    Discover every vehicle-like record across all installed doctypes
+    (ERPNext Vehicle, Fleet MS Truck, Fleet MS Trailers, and any future
+    doctype that has a plate-like field), normalise the registration number,
+    and enqueue a background fine-check for each unique, valid plate.
+
+    Duplicate plates (same plate on multiple doctypes) are only checked once.
+    The mark-as-PAID logic runs inside get_fine — no separate job is needed.
+    """
+    seen_plates = set()
+    enqueued = 0
+
+    for vehicle in get_vehicle_like_records():
+        plate = normalize_number_plate(vehicle.plate_number)
+        if not plate or not is_valid_number_plate(plate):
+            continue
+        if plate in seen_plates:
+            continue
+        seen_plates.add(plate)
+
         frappe.enqueue(
             "csf_tz.csf_tz.doctype.vehicle_fine_record.vehicle_fine_record.get_fine",
-            number_plate=vehicle["number_plate"] or vehicle["license_plate"] or vehicle["name"],
+            number_plate=plate,
+            queue="long",
         )
-        sleep(0.5)  
+        enqueued += 1
 
-    frappe.logger().info(f"Enqueued fine checks for {total_vehicles} vehicles")
-
-    frappe.enqueue(
-        "csf_tz.csf_tz.doctype.vehicle_fine_record.vehicle_fine_record.mark_old_records_as_paid",
+    frappe.logger().info(
+        f"Enqueued fine checks for {enqueued} unique vehicle-like records"
     )
-
-    return {"message": f"Enqueued fine checks for {total_vehicles} vehicles"}
-
-
-def mark_old_records_as_paid(batch_size=20):
-    """
-    Mark Vehicle Fine Records as PAID if they're no longer in the TPF system
-    This function is called after all get_fine calls complete
-    """
-    try:
-        unpaid_records = frappe.get_all(
-            "Vehicle Fine Record",
-            filters={"status": ["!=", "PAID"]},
-            fields=["name", "vehicle", "reference"],
-            limit_page_length=0
-        )
-
-        marked_as_paid = 0
-        for i, record in enumerate(unpaid_records):
-            try:
-                still_pending = get_fine(reference=record.get("reference"))
-                
-                if not still_pending or record.get("reference") not in still_pending:
-                    frappe.db.set_value(
-                        "Vehicle Fine Record",
-                        record.get("name"),
-                        "status",
-                        "PAID"
-                    )
-                    marked_as_paid += 1
-                
-                if i % 5 == 0:
-                    sleep(1)  
-                    
-            except Exception as e:
-                frappe.log_error(
-                    title=f"Error checking fine {record.get('reference')}",
-                    message=frappe.get_traceback()
-                )
-                continue
-
-        frappe.db.commit()
-        frappe.logger().info(f"Marked {marked_as_paid} old records as PAID")
-
-    except Exception as e:
-        frappe.log_error(
-            title="Error in mark_old_records_as_paid",
-            message=frappe.get_traceback()
-        )
+    return {"message": f"Enqueued fine checks for {enqueued} unique vehicle-like records"}
 
 
 @frappe.whitelist()
-def get_fine(number_plate=None, reference=None):
-    if not number_plate and not reference:
-        print_out(
-            _("Please provide either number plate or reference"),
-            alert=True,
-            add_traceback=True,
-            to_error_log=True,
-        )
-        return
+def get_fine(number_plate):
+    """
+    Query the TPF API for pending fines on the given number plate.
 
-    if number_plate and len(number_plate) < 7:
-        print_out(
-            f"Please provide a valid number plate for {number_plate}",
-            alert=True,
-            add_traceback=True,
-            to_error_log=True,
-        )
-        return
+    Behaviour:
+    - If the API returns pending transactions:
+        * Create a new Vehicle Fine Record for each reference not yet in ERPNext.
+        * Mark any existing PENDING records whose reference is no longer in the
+          API response as PAID (they have been settled).
+    - If the API returns no pending transactions:
+        * Mark all PENDING records for this plate as PAID.
 
-    fine_list = []
+    Returns a list of fine reference strings that are currently pending
+    according to the TPF API, or [] on any error.
+    """
+    number_plate = normalize_number_plate(number_plate)
+
+    if not number_plate:
+        frappe.log_error(
+            title="get_fine: missing number plate",
+            message="get_fine was called with an empty or None number plate",
+        )
+        return []
+
+    if not is_valid_number_plate(number_plate):
+        frappe.log_error(
+            title="get_fine: invalid number plate",
+            message=f"Skipping invalid plate: {number_plate}",
+        )
+        return []
+
     url = "https://tms.tpf.go.tz/api/OffenceCheck"
-    
     headers = {
         "Content-Type": "application/json",
         "Accept": "*/*",
@@ -141,100 +159,129 @@ def get_fine(number_plate=None, reference=None):
         "Referer": "https://tms.tpf.go.tz/",
         "Connection": "keep-alive",
     }
-
-    payload = {"vehicle": number_plate or reference}
+    payload = {"vehicle": number_plate}
 
     max_retries = 3
-    retry_delay = 5
-    
+    response = None  
+
     for attempt in range(max_retries):
         try:
-            sleep(retry_delay)
-            response = requests.post(url, json=payload, headers=headers, timeout=30)  # Increased timeout
+            if attempt > 0:
+                sleep(5 * attempt)
+
+            response = requests.post(url, json=payload, headers=headers, timeout=30)
             response.raise_for_status()
-            break  
-            
-        except (requests.exceptions.Timeout, requests.exceptions.ConnectionError) as e:
+            break 
+
+        except (requests.exceptions.Timeout, requests.exceptions.ConnectionError):
             if attempt < max_retries - 1:
-                retry_delay = 5 * (attempt + 1)  # 5s, 10s, 15s
                 continue
+            frappe.logger().warning(
+                f"[VehicleFine] Connection timeout for {number_plate} "
+                f"after {max_retries} retries"
+            )
+            return []
+
+        except requests.exceptions.HTTPError:
+            status = response.status_code if response is not None else 0
+            if status in (408, 429) or status >= 500:
+                if attempt < max_retries - 1:
+                    continue
+                frappe.logger().warning(
+                    f"[VehicleFine] HTTP {status} for {number_plate} "
+                    f"after {max_retries} retries"
+                )
+                return []
             else:
-                frappe.logger().warning(f"Connection timeout for {number_plate or reference} after {max_retries} retries")
+                frappe.log_error(
+                    title="TPF API Error",
+                    message=(
+                        f"HTTP {status} for {number_plate}: "
+                        f"{response.text[:500] if response is not None else ''}"
+                    ),
+                )
                 return []
-                
-        except requests.exceptions.HTTPError as e:
-            if response.status_code == 429:  # Too Many Requests - retry
-                if attempt < max_retries - 1:
-                    retry_delay = 10 * (attempt + 1)
-                    continue
-                else:
-                    frappe.logger().warning(f"Rate limit for {number_plate or reference} after {max_retries} retries")
-                    return []
-            elif response.status_code >= 500:  
-                if attempt < max_retries - 1:
-                    retry_delay = 10 * (attempt + 1)
-                    continue
-                else:
-                    frappe.logger().warning(f"Server error for {number_plate or reference} after {max_retries} retries")
-                    return []
-            else:  
-                frappe.log_error(title="TPF API Error", message=f"HTTP {response.status_code}: {str(e)}")
-                return []
-                
+
         except requests.exceptions.RequestException as e:
             frappe.log_error(title="TPF API Error", message=str(e))
             return []
 
+    if response is None:
+        return []
+
     try:
         result = response.json()
-    except Exception as e:
-        frappe.log_error("Invalid JSON", str(e))
-        frappe.throw("Invalid response format from traffic system")
+        result = decode_tpf_response(result)
+    except Exception:
+        frappe.log_error(
+            title="TPF API: Invalid JSON",
+            message=(
+                f"Non-JSON response for {number_plate}: "
+                f"{response.text[:500]}"
+            ),
+        )
+        return []
 
     data = result.get("pending_transactions", [])
-    vehicle_key = number_plate or reference
+    fine_list = []
 
     if data:
         fine_list = [fine.get("reference") for fine in data if fine.get("reference")]
         if not fine_list:
             return fine_list
 
-        filters = {"vehicle": vehicle_key, "status": ["!=", "PAID"], "reference": ["not in", fine_list]}
-        
-        existing_refs = frappe.get_all(
-            "Vehicle Fine Record",
-            filters={"vehicle": vehicle_key, "reference": ["in", fine_list]},
-            pluck="reference"
-        )
-
-        for record in frappe.get_all("Vehicle Fine Record", filters=filters, pluck="name"):
+        stale_filters = {
+            "vehicle": number_plate,
+            "status": ["!=", "PAID"],
+            "reference": ["not in", fine_list],
+        }
+        for record in frappe.get_all(
+            "Vehicle Fine Record", filters=stale_filters, pluck="name"
+        ):
             frappe.db.set_value("Vehicle Fine Record", record, "status", "PAID")
 
+        existing_refs = frappe.get_all(
+            "Vehicle Fine Record",
+            filters={"vehicle": number_plate, "reference": ["in", fine_list]},
+            pluck="reference",
+        )
         for fine in data:
             fine_ref = fine.get("reference")
-            if fine_ref and fine_ref not in existing_refs:
-                try:
-                    new_record = frappe.get_doc({
+            if not fine_ref or fine_ref in existing_refs:
+                continue
+            charge = fine.get("charge") or fine.get("amount")
+            penalty = fine.get("penalty")
+            try:
+                frappe.get_doc(
+                    {
                         "doctype": "Vehicle Fine Record",
-                        "vehicle": vehicle_key,
+                        "vehicle": number_plate,
                         "reference": fine_ref,
-                        "status": "PENDING",
-                        "amount": fine.get("amount"),
+                        "status": fine.get("status") or "PENDING",
+                        "licence": fine.get("licence"),
+                        "location": fine.get("location"),
+                        "officer": fine.get("officer"),
+                        "charge": charge,
+                        "penalty": penalty,
+                        "total": fine.get("total") or (flt(charge) + flt(penalty)),
                         "offence": fine.get("offence"),
-                        "fine_date": fine.get("date"),
-                    })
-                    new_record.insert(ignore_permissions=True)
-                except frappe.exceptions.DuplicateEntryError:
-                    pass  
-                except Exception as e:
-                    frappe.log_error(
-                        title=f"Error creating fine record for {vehicle_key}",
-                        message=frappe.get_traceback()
-                    )
-    else:
-        filters = {"vehicle": vehicle_key, "status": ["!=", "PAID"]}
+                        "issued_date": fine.get("issued_date") or fine.get("date"),
+                    }
+                ).insert(ignore_permissions=True)
+            except frappe.exceptions.DuplicateEntryError:
+                pass  
+            except Exception:
+                frappe.log_error(
+                    title=f"Error creating fine record for {number_plate}",
+                    message=frappe.get_traceback(),
+                )
 
-        for record in frappe.get_all("Vehicle Fine Record", filters=filters, pluck="name"):
+    else:
+        for record in frappe.get_all(
+            "Vehicle Fine Record",
+            filters={"vehicle": number_plate, "status": ["!=", "PAID"]},
+            pluck="name",
+        ):
             frappe.db.set_value("Vehicle Fine Record", record, "status", "PAID")
 
     frappe.db.commit()

--- a/csf_tz/hooks.py
+++ b/csf_tz/hooks.py
@@ -307,7 +307,8 @@ scheduler_events = {
 	"weekly": ["csf_tz.custom_api.make_stock_reconciliation_for_all_pending_material_request"],
 	"monthly": [
 		# "csf_tz.tasks.monthly",
-		"csf_tz.csf_tz.doctype.tz_insurance_cover_note.tz_insurance_cover_note.update_covernote_docs"
+		"csf_tz.csf_tz.doctype.tz_insurance_cover_note.tz_insurance_cover_note.update_covernote_docs",
+		"csf_tz.csf_tz.doctype.latra_licenses.latra_licenses.update_latra_records",
 	],
 }
 

--- a/csf_tz/vehicle_authority.py
+++ b/csf_tz/vehicle_authority.py
@@ -1,0 +1,88 @@
+import frappe
+
+
+PLATE_FIELD_CANDIDATES = (
+	"license_plate",
+	"plate_number",
+	"number_plate",
+	"registration_number",
+	"vehicle_number",
+	"truck_number",
+	"trailer_number",
+	"name",
+)
+
+
+def get_vehicle_plate(doc_or_values, meta=None):
+	"""Resolve a registration number from any vehicle-like document."""
+	if meta is None and getattr(doc_or_values, "doctype", None):
+		meta = doc_or_values.meta
+
+	for fieldname in PLATE_FIELD_CANDIDATES:
+		if fieldname != "name" and meta and not meta.has_field(fieldname):
+			continue
+
+		value = doc_or_values.get(fieldname) if fieldname != "name" else doc_or_values.get("name")
+		if value and str(value).strip():
+			return str(value).strip()
+
+
+def has_vehicle_plate_field(meta):
+	return any(
+		meta.has_field(fieldname)
+		for fieldname in PLATE_FIELD_CANDIDATES
+		if fieldname != "name"
+	)
+
+
+def get_vehicle_like_doctypes():
+	for doctype in frappe.get_all(
+		"DocType",
+		filters={"istable": 0, "issingle": 0},
+		pluck="name",
+	):
+		try:
+			meta = frappe.get_meta(doctype)
+		except Exception:
+			continue
+
+		if has_vehicle_plate_field(meta):
+			yield doctype, meta
+
+
+def get_vehicle_like_records():
+	for doctype, meta in get_vehicle_like_doctypes():
+		fields = ["name"]
+		fields.extend(
+			fieldname
+			for fieldname in PLATE_FIELD_CANDIDATES
+			if fieldname != "name" and meta.has_field(fieldname)
+		)
+
+		for row in frappe.get_all(doctype, fields=fields, limit_page_length=0):
+			plate_number = get_vehicle_plate(row, meta=meta)
+			if plate_number:
+				yield frappe._dict(
+					{
+						"doctype": doctype,
+						"name": row.name,
+						"plate_number": plate_number,
+					}
+				)
+
+
+def get_vehicle_docname_by_plate(plate_number):
+	if not plate_number or not frappe.db.exists("DocType", "Vehicle"):
+		return
+
+	meta = frappe.get_meta("Vehicle")
+	for fieldname in PLATE_FIELD_CANDIDATES:
+		if fieldname == "name":
+			vehicle_name = frappe.db.exists("Vehicle", plate_number)
+		elif meta.has_field(fieldname):
+			vehicle_name = frappe.db.get_value("Vehicle", {fieldname: plate_number}, "name")
+		else:
+			vehicle_name = None
+
+		if vehicle_name:
+			return vehicle_name


### PR DESCRIPTION
This update fixes major issues in how we fetch data for vehicle fines (TPF) and insurance cover notes (Tiramis).
Helper Function (vehicle_authority.py):
- Added a smart helper that automatically finds all vehicles, trucks, and trailers in the system by looking for license plate fields.                                                                                                                                                                                                                                                  Fines and Insurance Sync (vehicle_fine_record.py & tz_insurance_cover_note.py):
- Moved the syncing process to the background queue. This stops the system from freezing or timing out after 5 minutes when checking hundreds of vehicles.
- Added a check to skip duplicate license plates, so we don't ask the API for the same vehicle twice.
- Automatically cleans up spaces in license plates and skips empty or invalid ones.