### PR TITLE
fix: remove orphan OT component custom fields and doctypes

### DIFF
--- a/csf_tz/hooks.py
+++ b/csf_tz/hooks.py
@@ -130,6 +130,7 @@ after_migrate = [
 	"csf_tz.patches.custom_fields.vfd_providers_updated_custom_fields.execute",
 	"csf_tz.patches.custom_fields.attendance_overtime_calculation_custom_fields.execute",
 	"csf_tz.patches.migrate_vfd_providers_to_csf_tz.execute",
+	"csf_tz.patches.remove_ot_component_custom_fields.execute",
 ]
 
 # Desk Notifications

--- a/csf_tz/patches/remove_ot_component_custom_fields.py
+++ b/csf_tz/patches/remove_ot_component_custom_fields.py
@@ -8,7 +8,15 @@ CUSTOM_FIELDS = (
     "Salary Slip-salary_slip_ot_component",
 )
 
+ORPHAN_DOCTYPES = (
+    "Salary Slip OT Component",
+    "Employee OT Component",
+)
+
 
 def execute():
     for field_name in CUSTOM_FIELDS:
         frappe.delete_doc_if_exists("Custom Field", field_name, force=True)
+
+    for doctype in ORPHAN_DOCTYPES:
+        frappe.delete_doc_if_exists("DocType", doctype, force=True)


### PR DESCRIPTION
The Employee and Salary Slip forms had custom fields (overtime_components, employee_ot_component, salary_slip_ot_component) whose child DocTypes "Employee OT Component" and "Salary Slip OT Component" no longer exist in the code. This caused "DocType not found" errors when opening Employee or creating a Payroll Entry.