### PR TITLE
fix(hooks): remove dead Purchase Order validate hook

### DIFF
--- a/csf_tz/hooks.py
+++ b/csf_tz/hooks.py
@@ -318,10 +318,7 @@ doc_events = {
 		"validate": "csf_tz.csftz_hooks.budget.check_budget_for_purchase_invoice",
 	},
 	"Purchase Order": {
-		"validate": [
-			"csf_tz.custom_api.target_warehouse_based_price_list",
-			"csf_tz.csftz_hooks.budget.check_budget_for_purchase_invoice",
-		],
+		"validate": "csf_tz.csftz_hooks.budget.check_budget_for_purchase_invoice",
 	},
 	"Material Request": {
 		"before_save": "csf_tz.csftz_hooks.budget.check_budget_for_material_request",


### PR DESCRIPTION
target_warehouse_based_price_list was deleted from custom_api.py when the dynamic price list feature was removed, but the hooks.py reference survived a later reformat and caused an AttributeError on every Purchase Order save.