### PR TITLE
fix: split latra sync and notifications

### DIFF
--- a/csf_tz/csf_tz/doctype/latra_licenses/latra_licenses.py
+++ b/csf_tz/csf_tz/doctype/latra_licenses/latra_licenses.py
@@ -109,13 +109,8 @@ def update_latra_records(force=0):
 		}
 
 	frappe.db.commit()
-
-	offence_result = update_latra_offences(force=force)
-	notify_latra_license_expiry()
-	_log_sync_summary(license_result, offence_result)
 	return {
 		"licenses": license_result,
-		"offences": offence_result,
 	}
 
 
@@ -221,6 +216,38 @@ def update_latra_offences(force=0):
 		"total_vehicles": len(plates),
 		"completed_cycle": True,
 	}
+
+
+def send_pending_latra_offence_notifications():
+	for row in frappe.get_all(
+		"Latra Offence",
+		fields=[
+			"name",
+			"mv_reg_number",
+			"reference_number",
+			"amount",
+			"status",
+			"authority_notified_on_new",
+			"authority_last_notified_status",
+		],
+		limit_page_length=0,
+	):
+		values = {
+			"mv_reg_number": row.mv_reg_number,
+			"reference_number": row.reference_number,
+			"amount": row.amount,
+			"status": row.status,
+		}
+
+		if not row.authority_notified_on_new:
+			_notify_latra_offence(row.name, values, is_new=True)
+
+		last_status = row.authority_last_notified_status or ""
+		current_status = row.status or ""
+		if last_status and current_status and last_status != current_status:
+			_notify_latra_offence(row.name, values, is_new=False, old_status=last_status)
+
+	frappe.db.commit()
 def sync_all_latra_licenses(token):
 	plates = get_unique_vehicle_plates(
 		normalize_number_plate=normalize_number_plate,

--- a/csf_tz/csf_tz/doctype/tz_insurance_cover_note/tz_insurance_cover_note.py
+++ b/csf_tz/csf_tz/doctype/tz_insurance_cover_note/tz_insurance_cover_note.py
@@ -39,7 +39,6 @@ def update_covernote_docs():
 		fetch_and_update_covernote(plate)
 		processed += 1
 
-	notify_tira_covernote_expiry()
 	frappe.logger().info(f"[CoverNote] Processed covernote updates for {processed} vehicles")
 	return {"message": f"Processed covernote updates for {processed} vehicles"}
 
@@ -174,6 +173,8 @@ def notify_tira_covernote_expiry():
 				},
 				update_modified=False,
 			)
+
+	frappe.db.commit()
 
 def get_covernote_details(regnumber):
 	"""Fetch motor insurance details from tira

--- a/csf_tz/csf_tz/doctype/vehicle_fine_record/vehicle_fine_record.py
+++ b/csf_tz/csf_tz/doctype/vehicle_fine_record/vehicle_fine_record.py
@@ -373,3 +373,30 @@ def _notify_vehicle_fine_status_change(docname, vehicle, old_status, new_status)
             new_status or "",
             update_modified=False,
         )
+
+
+def send_pending_vehicle_fine_notifications():
+    for row in frappe.get_all(
+        "Vehicle Fine Record",
+        fields=[
+            "name",
+            "vehicle",
+            "reference",
+            "status",
+            "total",
+            "authority_notified_on_new",
+            "authority_last_notified_status",
+        ],
+        limit_page_length=0,
+    ):
+        doc = frappe._dict(row)
+
+        if not doc.authority_notified_on_new:
+            _notify_vehicle_fine_new(doc)
+
+        last_status = doc.authority_last_notified_status or ""
+        current_status = doc.status or ""
+        if last_status and current_status and last_status != current_status:
+            _notify_vehicle_fine_status_change(doc.name, doc.vehicle, last_status, current_status)
+
+    frappe.db.commit()

--- a/csf_tz/hooks.py
+++ b/csf_tz/hooks.py
@@ -303,6 +303,8 @@ scheduler_events = {
 		"csf_tz.csftz_hooks.additional_salary.generate_additional_salary_records",
 		"csf_tz.csftz_hooks.exchange_calculations.update_pending_transactions",
 		"csf_tz.csf_tz.doctype.vehicle_sync_task.processor.seed_vehicle_sync_queue",
+		"csf_tz.csf_tz.doctype.latra_licenses.latra_licenses.update_latra_offences",
+		"csf_tz.vehicle_authority.run_daily_authority_notifications",
 	],
 	# "hourly": [
 	# 	"csf_tz.tasks.hourly"

--- a/csf_tz/vehicle_authority.py
+++ b/csf_tz/vehicle_authority.py
@@ -195,3 +195,21 @@ def send_authority_notification(reference_type, subject, message, now=True):
 		now=now,
 	)
 	return {"sent": True, "reason": "sent", "recipients": recipients}
+
+
+def run_daily_authority_notifications():
+	from csf_tz.csf_tz.doctype.latra_licenses.latra_licenses import (
+		notify_latra_license_expiry,
+		send_pending_latra_offence_notifications,
+	)
+	from csf_tz.csf_tz.doctype.tz_insurance_cover_note.tz_insurance_cover_note import (
+		notify_tira_covernote_expiry,
+	)
+	from csf_tz.csf_tz.doctype.vehicle_fine_record.vehicle_fine_record import (
+		send_pending_vehicle_fine_notifications,
+	)
+
+	notify_latra_license_expiry()
+	send_pending_latra_offence_notifications()
+	notify_tira_covernote_expiry()
+	send_pending_vehicle_fine_notifications()


### PR DESCRIPTION
Split LATRA licence and offence processing so licences stay on the monthly schedule, offences run daily, and authority notifications run every day independently of the sync jobs.