### PR TITLE
fix: avoid monkey patch loading during site-less builds

### DIFF
--- a/csf_tz/__init__.py
+++ b/csf_tz/__init__.py
@@ -19,10 +19,16 @@ def load_monkey_patches():
 	if patches_loaded:
 		return
 
-	patches_loaded = True
+	# Bench-level commands such as asset builds can run without a site context.
+	# Avoid querying installed apps in that case, because it attempts a database
+	# connection and fails with "site must be fully initialized, db_name missing".
+	if not getattr(frappe.local, "site", None):
+		return
 
 	if app_name not in frappe.get_installed_apps():
 		return
+
+	patches_loaded = True
 
 	for module_name in os.listdir(frappe.get_app_path(app_name, "monkey_patches")):
 		if not module_name.endswith(".py") or module_name == "__init__.py":


### PR DESCRIPTION
## Summary

Prevent `csf_tz` from attempting to load monkey patches during bench-level/site-less commands such as asset builds.

## Problem

`load_monkey_patches()` called `frappe.get_installed_apps()` unconditionally. During commands such as `frappe build --app csf_tz`, there may be no initialized site/database context, causing Frappe to attempt a database connection and fail with:

`AssertionError: site must be fully initialized, db_name missing`

The function also set `patches_loaded = True` before verifying that patches could actually be loaded, which could suppress later loading in the same process.

## Fix

- Return early when `frappe.local.site` is not available.
- Only call `frappe.get_installed_apps()` when a site context exists.
- Set `patches_loaded = True` only after the site and installed-app checks succeed.

This keeps normal site/database initialization behavior unchanged while allowing site-less build commands to complete.