### PR TITLE
fix: add dedicated group for multicurrency bank charges

### DIFF
--- a/csf_tz/setup_data/accounts.json
+++ b/csf_tz/setup_data/accounts.json
@@ -31,7 +31,7 @@
   },
   {
     "doctype": "Account",
-    "account_name": "Bank Charges",
+    "account_name": "Bank Charges Accounts",
     "company": "{company}",
     "account_currency": "TZS",
     "parent_account": "Financial Charges - {abbr}",
@@ -147,7 +147,7 @@
     "account_name": "Bank Charges TZS",
     "company": "{company}",
     "account_currency": "TZS",
-    "parent_account": "Bank Charges - {abbr}",
+    "parent_account": "Bank Charges Accounts - {abbr}",
     "root_type": "Expense",
     "report_type": "Profit and Loss"
   },


### PR DESCRIPTION
## Summary
- replace the conflicting `Bank Charges` setup group with a dedicated `Bank Charges Accounts` group
- keep the group under `Financial Charges`
- create `Bank Charges TZS` beneath `Bank Charges Accounts`
- avoid collisions when an existing ERPNext `Bank Charges` account is already a ledger (`is_group = 0`)

## Resulting hierarchy

```text
Financial Charges
└── Bank Charges Accounts   [Group]
    └── Bank Charges TZS    [Ledger]
```

This addresses the install failure where `Bank Charges TZS` was being created below an existing ledger account named `Bank Charges`.