### PR TITLE
fix: skip monkey patch loading in site-less contexts

### DIFF
--- a/csf_tz/__init__.py
+++ b/csf_tz/__init__.py
@@ -19,6 +19,11 @@ def load_monkey_patches():
 	if patches_loaded:
 		return
 
+	# Site-less contexts (`bench build`, etc.) must not force a DB
+	# connection; the frappe.connect patch loads these later anyway.
+	if not getattr(frappe.local, "site", None):
+		return
+
 	patches_loaded = True
 
 	if app_name not in frappe.get_installed_apps():


### PR DESCRIPTION
The patched frappe.get_hooks loads monkey patches on every call, which triggers frappe.get_installed_apps() and forces a DB connection. In site-less contexts like `bench build`, no site is bound, so connect() fails with "site must be fully initialized, db_name missing" — breaking app installation during the asset build step.

Bail out of load_monkey_patches() when frappe.local.site is not set, before marking patches as loaded, so the patched frappe.connect still loads them once a real site connection is established.