### PR TITLE
fix: skip doctype revalidation when installing property setters from JSON

### DIFF
--- a/csf_tz/utils/create_property_setter.py
+++ b/csf_tz/utils/create_property_setter.py
@@ -58,6 +58,7 @@ def create_property_setter_from_json(property_setters_obj):
 			value=property_setter_dict["value"],
 			property_type=property_setter_dict["property_type"],
 			for_doctype=for_doctype,
+			validate_fields_for_doctype=False,
 		)
 
 


### PR DESCRIPTION
Consecutive naming_series setters (options, then default) hit Frappe v16's default-in-options check against a stale meta cache, failing install.